### PR TITLE
feat: call onCancel on modal close

### DIFF
--- a/packages/connect-ui/src/components/modal/modal.tsx
+++ b/packages/connect-ui/src/components/modal/modal.tsx
@@ -28,6 +28,7 @@ export class Modal {
 
   handleCloseModal() {
     this.modalEl.remove();
+    this.authOptions.onCancel?.();
   }
 
   handleDownloadPath(browser: string) {


### PR DESCRIPTION
Calling `onCancel` callback when the user closes modal

closes #185 
