### PR TITLE
replace stacks wallet to Hiro wallet - Mozilla Addon URL

### DIFF
--- a/packages/connect-ui/src/components/modal/modal.tsx
+++ b/packages/connect-ui/src/components/modal/modal.tsx
@@ -12,7 +12,7 @@ const BRAVE_BROWSER_URL = 'https://brave.com/';
 const FIREFOX_BROWSER_URL = 'https://www.mozilla.org/en-US/';
 const CHROME_STORE_URL =
   'https://chrome.google.com/webstore/detail/stacks-wallet/ldinpeekobnhjjdofggfgjlcehhmanlj/';
-const FIREFOX_STORE_URL = 'https://addons.mozilla.org/en-US/firefox/addon/stacks-wallet/';
+const FIREFOX_STORE_URL = 'https://addons.mozilla.org/en-US/firefox/addon/hiro-wallet/';
 @Component({
   tag: 'connect-modal',
   styleUrl: 'modal.scss',


### PR DESCRIPTION
## Description
When clicking on "Download Hiro Wallet" it redirects to [this link](https://addons.mozilla.org/en-US/firefox/addon/stacks-wallet/) (404), have replaced this with [Hiro wallet Mozilla Addon Link](https://addons.mozilla.org/en-US/firefox/addon/hiro-wallet/)
![image](https://user-images.githubusercontent.com/58929492/158016516-bdacd0cb-13e3-419e-96f0-9592bfd14aec.png)

1. Motivation for change: People may leave website as Mozilla Addon page shows 404. 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

Provide context on how tests should be performed.

1. Is testing required for this change? No
2. If it’s a bug fix, list steps to reproduce the bug: NA
3. Briefly mention affected code paths: NA
4. List other affected projects if possible: NA
5. Things to watch out for when testing: NA

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `yarn lerna run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @hstove or @kyranjamie or @aulneau for review
