### PR TITLE
fix: paths to download the hiro wallet

### DIFF
--- a/.changeset/ninety-taxis-grab.md
+++ b/.changeset/ninety-taxis-grab.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect-ui': minor
+---
+
+This updates our old 'stacks-wallet' download paths to be 'hiro-wallet'.

--- a/packages/connect-ui/src/components/modal/modal.tsx
+++ b/packages/connect-ui/src/components/modal/modal.tsx
@@ -11,8 +11,8 @@ const CHROME_BROWSER_URL = 'https://www.google.com/chrome/';
 const BRAVE_BROWSER_URL = 'https://brave.com/';
 const FIREFOX_BROWSER_URL = 'https://www.mozilla.org/en-US/';
 const CHROME_STORE_URL =
-  'https://chrome.google.com/webstore/detail/stacks-wallet/ldinpeekobnhjjdofggfgjlcehhmanlj/';
-const FIREFOX_STORE_URL = 'https://addons.mozilla.org/en-US/firefox/addon/stacks-wallet/';
+  'https://chrome.google.com/webstore/detail/hiro-wallet/ldinpeekobnhjjdofggfgjlcehhmanlj/';
+const FIREFOX_STORE_URL = 'https://addons.mozilla.org/en-US/firefox/addon/hiro-wallet/';
 @Component({
   tag: 'connect-modal',
   styleUrl: 'modal.scss',


### PR DESCRIPTION
This PR updates our wallet download paths to be 'hiro-wallet'. In addition, I have bumped the @stacks/connect package version manually to get it in sync with our current npm published version (6.4.0).