### PR TITLE
feat: add accounts request stubs

### DIFF
--- a/packages/connect/src/accounts.ts
+++ b/packages/connect/src/accounts.ts
@@ -1,0 +1,25 @@
+import { AccountsRequestOptions } from './types/accounts';
+import { getStacksProvider } from './utils';
+
+export const requestAccounts = async (accountsOptions: AccountsRequestOptions) => {
+  const provider = getStacksProvider();
+  if (!provider) {
+    throw new Error('Unable to request accounts without Hiro Wallet extension');
+  }
+
+  const { onFinish, onCancel } = accountsOptions;
+
+  // todo: should request accounts tie into userSession (e.g. persist accounts)?
+  // const userSession = getOrCreateUserSession(_userSession);
+
+  // todo: should request accounts be encrypted using a transit key?
+  // const transitKey = userSession.generateAndStoreTransitKey();
+
+  try {
+    const accounts = await provider.accountsRequest();
+    onFinish?.({ accounts }); // todo: inside object for future extensibility (or directly as single/only parameter)
+  } catch (error) {
+    console.error('[Connect] Error during accounts request', error);
+    onCancel?.();
+  }
+};

--- a/packages/connect/src/types/accounts.ts
+++ b/packages/connect/src/types/accounts.ts
@@ -1,0 +1,16 @@
+import { UserSession } from '@stacks/auth';
+
+export interface AccountsRequestOptions {
+  manifestPath?: string;
+  onFinish?: (payload: FinishedAccountsData) => void;
+  onCancel?: () => void;
+  userSession?: UserSession;
+  appDetails: {
+    name: string;
+    icon: string;
+  };
+}
+
+export interface FinishedAccountsData {
+  accounts: string[];
+}

--- a/packages/connect/src/types/provider.ts
+++ b/packages/connect/src/types/provider.ts
@@ -17,6 +17,12 @@ export interface StacksProvider {
    * @returns an authResponse string in the form of a JSON web token
    */
   authenticationRequest(payload: string): Promise<string>;
+  /**
+   * Make an accounts request
+   *
+   * @returns an array of selected account addresses
+   */
+  accountsRequest(): Promise<string[]>;
   getProductInfo:
     | undefined
     | (() => {


### PR DESCRIPTION
## wip 🚧
- adds stubs for application-side interface

---

probably needs the changes wallet-side along these lines:
- add event listener in [content-script.ts →](https://github.com/hirosystems/stacks-wallet-web/blob/dev/src/content-scripts/content-script.ts#L76-L96)
- add handler on [StacksProvider →](https://github.com/hirosystems/stacks-wallet-web/blob/dev/src/inpage/inpage.ts#L63)
- add "finalizer" (to use from hook?) similar to [finalize-auth-response →](https://github.com/hirosystems/stacks-wallet-web/blob/dev/src/app/common/actions/finalize-auth-response.ts#L24)
