### PR TITLE
fix(tx-signing): allow signing of unsigned jwt payloads when no priva…

### DIFF
--- a/.changeset/hungry-berries-crash.md
+++ b/.changeset/hungry-berries-crash.md
@@ -1,0 +1,6 @@
+---
+'@stacks/connect': minor
+'@stacks/connect-react': minor
+---
+
+Allow initiating transactions without a private key

--- a/packages/connect/src/signature/index.ts
+++ b/packages/connect/src/signature/index.ts
@@ -4,7 +4,6 @@ import { getStacksProvider } from '../utils';
 import { StacksTestnet } from '@stacks/network';
 import {
   CommonSignatureRequestOptions,
-  SignatureData,
   SignatureOptions,
   SignaturePayload,
   SignaturePopup,
@@ -56,7 +55,7 @@ async function openSignaturePopup({ token, options }: SignaturePopup) {
   try {
     const signatureResponse = await provider.signatureRequest(token);
 
-    options.onFinish?.(signatureResponse as SignatureData);
+    options.onFinish?.(signatureResponse);
   } catch (error) {
     console.error('[Connect] Error during signature request', error);
     options.onCancel?.();


### PR DESCRIPTION
As discussed with @janniks, this PR modifies the existing Connect helper methods in a way that should also allow transactions to be initiated when an app has requested accounts details with `stx_requestAccounts`, rather than traditional Stacks auth.

This is also required for transactions to be created when doing jwt auth signing with a Ledger.