### PR TITLE
Feat/arbitrary message signing structured data

### DIFF
--- a/.changeset/tidy-lemons-love.md
+++ b/.changeset/tidy-lemons-love.md
@@ -1,0 +1,6 @@
+---
+'@stacks/connect': minor
+'@stacks/connect-react': minor
+---
+
+Add helper to request the signature of a structure data (Clarity Value)

--- a/packages/connect-react/src/react/hooks/use-connect.ts
+++ b/packages/connect-react/src/react/hooks/use-connect.ts
@@ -16,10 +16,12 @@ import {
   STXTransferRegularOptions,
   STXTransferSponsoredOptions,
   FinishedAuthData,
+  openStructuredDataSignatureRequestPopup,
   openSignatureRequestPopup,
 } from '@stacks/connect';
 import { ConnectContext, ConnectDispatchContext, States } from '../components/connect/context';
 import { SignatureRequestOptions } from '@stacks/connect';
+import { StructuredDataSignatureRequestOptions } from '@stacks/connect/src/types/structuredDataSignature';
 
 const useConnectDispatch = () => {
   const dispatch = useContext(ConnectDispatchContext);
@@ -116,6 +118,14 @@ export const useConnect = () => {
     });
   }
 
+  function signStructuredData(options: StructuredDataSignatureRequestOptions) {
+    return openStructuredDataSignatureRequestPopup({
+      ...options,
+      authOrigin: authOptions.authOrigin,
+      appDetails: authOptions.appDetails,
+    });
+  }
+
   return {
     isOpen,
     isAuthenticating,
@@ -129,5 +139,6 @@ export const useConnect = () => {
     doContractDeploy,
     doSTXTransfer,
     sign,
+    signStructuredData,
   };
 };

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,6 +1,7 @@
 export * from './auth';
 export * from './transactions';
 export * from './signature';
+export * from './signature/structuredData';
 export * from './types';
 export * from './utils';
 export * from './ui';

--- a/packages/connect/src/signature/index.ts
+++ b/packages/connect/src/signature/index.ts
@@ -3,6 +3,7 @@ import { ChainID } from '@stacks/transactions';
 import { getStacksProvider } from '../utils';
 import { StacksTestnet } from '@stacks/network';
 import {
+  CommonSignatureRequestOptions,
   SignatureData,
   SignatureOptions,
   SignaturePayload,
@@ -11,7 +12,7 @@ import {
 } from 'src/types/signature';
 import { getKeys, getUserSession } from '../transactions';
 
-function getStxAddress(options: SignatureRequestOptions) {
+function getStxAddress(options: CommonSignatureRequestOptions) {
   const { userSession, network } = options;
 
   if (!userSession || !network) return undefined;
@@ -24,10 +25,10 @@ function getStxAddress(options: SignatureRequestOptions) {
   return address;
 }
 
-function getDefaultSignatureRequestOptions(options: SignatureRequestOptions) {
+export function getDefaultSignatureRequestOptions(options: CommonSignatureRequestOptions) {
   const network = options.network || new StacksTestnet();
   const userSession = getUserSession(options.userSession);
-  const defaults: SignatureRequestOptions = {
+  const defaults: CommonSignatureRequestOptions = {
     ...options,
     network,
     userSession,

--- a/packages/connect/src/signature/structuredData.ts
+++ b/packages/connect/src/signature/structuredData.ts
@@ -1,0 +1,65 @@
+import { getStacksProvider } from '../utils';
+import { getKeys } from '../transactions';
+import { getDefaultSignatureRequestOptions } from '.';
+import {
+  StructuredDataSignatureOptions,
+  StructuredDataSignaturePayload,
+  StructuredDataSignaturePopup,
+  StructuredDataSignatureRequestOptions,
+} from 'src/types/structuredDataSignature';
+import { TokenSigner } from 'jsontokens';
+import { serializeCV } from '@stacks/transactions';
+
+async function generateTokenAndOpenPopup<T extends StructuredDataSignatureOptions>(
+  options: T,
+  makeTokenFn: (options: T) => Promise<string>
+) {
+  const token = await makeTokenFn({
+    ...getDefaultSignatureRequestOptions(options),
+    ...options,
+  } as T);
+  return openStructuredDataSignaturePopup({ token, options });
+}
+
+async function signPayload(payload: StructuredDataSignaturePayload, privateKey: string) {
+  const tokenSigner = new TokenSigner('ES256k', privateKey);
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  return tokenSigner.signAsync({
+    ...payload,
+    message: serializeCV(payload.message).toString('hex'),
+  } as any);
+}
+
+export async function signStructuredMessage(options: StructuredDataSignatureRequestOptions) {
+  const { userSession, ..._options } = options;
+  const { privateKey, publicKey } = getKeys(userSession);
+
+  const payload: StructuredDataSignaturePayload = {
+    ..._options,
+    publicKey,
+  };
+
+  return signPayload(payload, privateKey);
+}
+
+async function openStructuredDataSignaturePopup({ token, options }: StructuredDataSignaturePopup) {
+  const provider = getStacksProvider();
+  if (!provider) {
+    throw new Error('Hiro Wallet not installed.');
+  }
+
+  try {
+    const signatureResponse = await provider.structuredDataSignatureRequest(token);
+
+    options.onFinish?.(signatureResponse);
+  } catch (error) {
+    console.error('[Connect] Error during signature request', error);
+    options.onCancel?.();
+  }
+}
+
+export function openStructuredDataSignatureRequestPopup(
+  options: StructuredDataSignatureRequestOptions
+) {
+  return generateTokenAndOpenPopup(options, signStructuredMessage);
+}

--- a/packages/connect/src/types/provider.ts
+++ b/packages/connect/src/types/provider.ts
@@ -19,6 +19,7 @@ export interface StacksProvider {
    */
   authenticationRequest(payload: string): Promise<string>;
   signatureRequest(payload: string): Promise<SignatureData>;
+  structuredDataSignatureRequest(payload: string): Promise<SignatureData>;
   getProductInfo:
     | undefined
     | (() => {

--- a/packages/connect/src/types/signature.ts
+++ b/packages/connect/src/types/signature.ts
@@ -1,25 +1,28 @@
-import type { AuthOptions } from '../types/auth';
-import { StacksNetwork } from '@stacks/network';
 import { UserSession } from '@stacks/auth';
+import { StacksNetwork } from '@stacks/network';
+import type { AuthOptions } from '../types/auth';
 
-type Finished = (data: SignatureData) => void;
-type Canceled = () => void;
+export type SignatureFinished = (data: SignatureData) => void;
+export type SignatureCanceled = () => void;
 
-export interface SignatureRequestOptions {
+export interface CommonSignatureRequestOptions {
   appDetails?: AuthOptions['appDetails'];
   authOrigin?: string;
-  message: string;
   network?: StacksNetwork;
   stxAddress?: string;
   userSession?: UserSession;
-  onFinish?: Finished;
-  onCancel?: Canceled;
+  onFinish?: SignatureFinished;
+  onCancel?: SignatureCanceled;
+}
+
+export interface SignatureRequestOptions extends CommonSignatureRequestOptions {
+  message: string;
 }
 
 export interface SignatureOptions {
   message: string;
-  onFinish?: Finished;
-  onCancel?: Canceled;
+  onFinish?: SignatureFinished;
+  onCancel?: SignatureCanceled;
 }
 
 export interface SignaturePopup {
@@ -27,8 +30,18 @@ export interface SignaturePopup {
   options: SignatureOptions;
 }
 
-export interface SignaturePayload {
+export interface SignaturePayload extends CommonSignaturePayload {
   message: string;
+}
+
+export interface SignatureData {
+  /* Hex encoded DER signature */
+  signature: string;
+  /* Hex encoded private string taken from privateKey */
+  publicKey: string;
+}
+
+export interface CommonSignaturePayload {
   publicKey: string;
   /**
    * Provide the Hiro Wallet with a suggested account to sign this transaction with.
@@ -37,11 +50,4 @@ export interface SignaturePayload {
   stxAddress?: string;
   appDetails?: AuthOptions['appDetails'];
   network?: StacksNetwork;
-}
-
-export interface SignatureData {
-  /* Hex encoded DER signature */
-  signature: string;
-  /* Hex encoded private string taken from privateKey */
-  publicKey: string;
 }

--- a/packages/connect/src/types/structuredDataSignature.ts
+++ b/packages/connect/src/types/structuredDataSignature.ts
@@ -1,0 +1,26 @@
+import { ClarityValue } from '@stacks/transactions';
+import {
+  CommonSignaturePayload,
+  CommonSignatureRequestOptions,
+  SignatureCanceled,
+  SignatureFinished,
+} from './signature';
+
+export interface StructuredDataSignatureRequestOptions extends CommonSignatureRequestOptions {
+  message: ClarityValue;
+}
+
+export interface StructuredDataSignatureOptions {
+  message: ClarityValue;
+  onFinish?: SignatureFinished;
+  onCancel?: SignatureCanceled;
+}
+
+export type StructuredDataSignaturePopup = {
+  token: string;
+  options: StructuredDataSignatureOptions;
+};
+
+export interface StructuredDataSignaturePayload extends CommonSignaturePayload {
+  message: ClarityValue;
+}


### PR DESCRIPTION
This adds the ability to sign structured data (ClarityValue)
see https://github.com/hirosystems/stacks-wallet-web/issues/2387

The ClarityValue is serialized in hex format before being signed (with jsontoken) and passed to the web wallet.