### PR TITLE
feat: add react 18 support to connect-react

### DIFF
--- a/packages/connect-react/package.json
+++ b/packages/connect-react/package.json
@@ -60,7 +60,7 @@
   "module": "dist/connect-react.esm.js",
   "peerDependencies": {
     "@stacks/connect": "6.7.0",
-    "react": "^16.x || 17.x",
-    "react-dom": "^16.x || 17.x"
+    "react": "^16.x || 17.x || 18.x",
+    "react-dom": "^16.x || 17.x || 18.x"
   }
 }


### PR DESCRIPTION
## Description

Add react 18 support to connect-react, I tested it on a new next.js app using react 18 and didn't face any issue.

Closes https://github.com/hirosystems/connect/issues/213

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `yarn lerna run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @hstove or @kyranjamie or @aulneau for review
