### PR TITLE
[poc] add static stencil component

### DIFF
--- a/.changeset/yellow-wasps-look.md
+++ b/.changeset/yellow-wasps-look.md
@@ -1,0 +1,6 @@
+---
+'@stacks/connect': patch
+'@stacks/connect-ui': patch
+---
+
+Add static show method

--- a/packages/connect-ui/stencil.config.ts
+++ b/packages/connect-ui/stencil.config.ts
@@ -11,6 +11,9 @@ export const config: Config = {
       esmLoaderPath: '../loader',
     },
     {
+      type: 'dist-custom-elements',
+    },
+    {
       type: 'docs-readme',
     },
     {

--- a/packages/connect/src/ui.ts
+++ b/packages/connect/src/ui.ts
@@ -1,6 +1,7 @@
 import { authenticate } from './auth';
 import type { AuthOptions } from './types/auth';
 import { defineCustomElements } from '@stacks/connect-ui/loader';
+import { ConnectModal } from '@stacks/connect-ui/dist/components/connect-modal';
 import { getStacksProvider } from './utils';
 
 export const showConnect = (authOptions: AuthOptions) => {
@@ -10,6 +11,31 @@ export const showConnect = (authOptions: AuthOptions) => {
   }
   if (typeof window !== undefined) {
     void defineCustomElements(window);
+    const element = document.createElement('connect-modal');
+    element.authOptions = authOptions;
+    document.body.appendChild(element);
+    const handleEsc = (ev: KeyboardEvent) => {
+      if (ev.key === 'Escape') {
+        document.removeEventListener('keydown', handleEsc);
+        element.remove();
+      }
+    };
+    document.addEventListener('keydown', handleEsc);
+  }
+};
+
+export const showConnectStatic = (authOptions: AuthOptions) => {
+  if (getStacksProvider()) {
+    void authenticate(authOptions);
+    return;
+  }
+
+  if (typeof window?.customElements?.define === 'function') {
+    // supports custom elements
+    if (customElements.get('connect-modal') === undefined) {
+      // avoid repeat defines
+      customElements.define('connect-modal', ConnectModal);
+    }
     const element = document.createElement('connect-modal');
     element.authOptions = authOptions;
     document.body.appendChild(element);


### PR DESCRIPTION
- adds `dist-custom-elements` distribution of `connect-ui`, since rollup-based projects don't handle dynamic loaded stencil well
- the new custom element is loaded (non-dynamically) in the new `showConnectStatic` method (just a copy of `showConnect` without dynamic loading)

using `*Static` would always bundle the connect-ui (ideally only shown when somebody has an incompatible browser, or is missing the wallet extension) into a project. however, developers could adjust their configs (e.g. rollup > `manualChunks`) to achieve similar dynamic loading/chunking, but handled by the last bundler in the build step (rather than stencil before distribution, which is optimized for webpack)