### PR TITLE
feat: add stub rpc request types to provider

### DIFF
--- a/packages/connect/src/types/provider.ts
+++ b/packages/connect/src/types/provider.ts
@@ -20,6 +20,7 @@ export interface StacksProvider {
   authenticationRequest(payload: string): Promise<string>;
   signatureRequest(payload: string): Promise<SignatureData>;
   structuredDataSignatureRequest(payload: string): Promise<SignatureData>;
+  request(method: string, params?: any[]): Promise<Record<string, any>>;
   getProductInfo:
     | undefined
     | (() => {


### PR DESCRIPTION
This PR adds the loosely-typed provider method needed for https://github.com/hirosystems/stacks-wallet-web/pull/2378

I reckon there's a design problem here, though. The wallet itself is responsible for the definition its provider, so it's problematic that we first need to modify connect, before being able to modify the wallet. Conceptually, the way I see it, connect consumes the wallet. Yet, this dependency means they consume each other.

<details>
<summary>Note on direction/SIPs</summary>


Eventually, when there are many wallet providers, we may have a full SIP with a provider spec, that might also include tooling such as a distributed provider type package. This would be great. But until then, it's a headache to keep the provider implementation and corresponding types in a separate package.

</details>


Any suggestions on the best way to handle this? Metamask has the provider in a separate package. Should we do the same, or just move it to the wallet for now? 