### PR TITLE
fix: change relative import

### DIFF
--- a/.changeset/good-deers-guess.md
+++ b/.changeset/good-deers-guess.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Fix relative import

--- a/packages/connect/src/signature/index.ts
+++ b/packages/connect/src/signature/index.ts
@@ -1,15 +1,15 @@
-import { TokenSigner } from 'jsontokens';
-import { ChainID } from '@stacks/transactions';
-import { getStacksProvider } from '../utils';
 import { StacksTestnet } from '@stacks/network';
+import { ChainID } from '@stacks/transactions';
+import { TokenSigner } from 'jsontokens';
+import { getKeys, getUserSession } from '../transactions';
 import {
   CommonSignatureRequestOptions,
   SignatureOptions,
   SignaturePayload,
   SignaturePopup,
   SignatureRequestOptions,
-} from 'src/types/signature';
-import { getKeys, getUserSession } from '../transactions';
+} from '../types/signature';
+import { getStacksProvider } from '../utils';
 
 function getStxAddress(options: CommonSignatureRequestOptions) {
   const { userSession, network } = options;

--- a/packages/connect/src/signature/structuredData.ts
+++ b/packages/connect/src/signature/structuredData.ts
@@ -1,14 +1,14 @@
-import { getStacksProvider } from '../utils';
-import { getKeys } from '../transactions';
+import { serializeCV } from '@stacks/transactions';
+import { TokenSigner } from 'jsontokens';
 import { getDefaultSignatureRequestOptions } from '.';
+import { getKeys } from '../transactions';
 import {
   StructuredDataSignatureOptions,
   StructuredDataSignaturePayload,
   StructuredDataSignaturePopup,
   StructuredDataSignatureRequestOptions,
-} from 'src/types/structuredDataSignature';
-import { TokenSigner } from 'jsontokens';
-import { serializeCV } from '@stacks/transactions';
+} from '../types/structuredDataSignature';
+import { getStacksProvider } from '../utils';
 
 async function generateTokenAndOpenPopup<T extends StructuredDataSignatureOptions>(
   options: T,


### PR DESCRIPTION
changes ~absolute import to relative. projects using connect may think `src/...` refers to an npm module.

```diff
- from 'src/types/signature';
+ from '../types/signature';
```