### PR TITLE
fix: add changeset to update stencil components

### DIFF
--- a/.changeset/six-years-fail.md
+++ b/.changeset/six-years-fail.md
@@ -1,0 +1,7 @@
+---
+'@stacks/connect': patch
+'@stacks/connect-react': patch
+'@stacks/connect-ui': patch
+---
+
+Update stencil components


### PR DESCRIPTION
- previous deploy missed `connect-ui`; forcing `patch` on all packages