### PR TITLE
ci: remove commitlint

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,16 +16,6 @@ jobs:
           echo "Is a fork: ${{ env.NPM_TOKEN == '' }}"
           echo "::set-output name=is_not_fork::${{ env.NPM_TOKEN != '' }}"
 
-  commitlint:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v1
-
   code_checks:
     name: Code checks
     runs-on: ubuntu-latest


### PR DESCRIPTION
- removes commitlint from CI

we don't generate changelogs from commit messages (but rather from changesets). right now, it's just annoying to manage commit lints for contributors. if we don't like incoming commit messages, we can still squash-merge into a nicer message.

we could go further and also remove husky from the repo?