### PR TITLE
fix(ledger): missing stx address prop

### DIFF
--- a/.changeset/modern-ghosts-remember.md
+++ b/.changeset/modern-ghosts-remember.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Fixes issue where STX address not passed to wallet in Ledger mode

--- a/packages/connect/src/transactions/index.ts
+++ b/packages/connect/src/transactions/index.ts
@@ -77,30 +77,17 @@ export function getStxAddress(options: TransactionOptions) {
 function getDefaults(options: TransactionOptions) {
   const network = options.network || new StacksTestnet();
 
-  // Legacy auth using localstorage with appPrivateKey
-  if (hasAppPrivateKey(options.userSession)) {
-    const userSession = getUserSession(options.userSession);
-    const defaults: TransactionOptions = {
-      ...options,
-      network,
-      userSession,
-    };
+  const userSession = getUserSession(options.userSession);
+  const defaults: TransactionOptions = {
+    ...options,
+    network,
+    userSession,
+  };
 
-    return {
-      stxAddress: getStxAddress(defaults),
-      ...defaults,
-    };
-  }
-
-  // User has not authed, we're relying on the app having previously having been
-  // given permissions from  `stx_requestAccounts`, and the wallet recognising the app's origin
-  // const hasSetRequiredStxAddressPropForRequestAccountFlow = 'stxAddress' in options;
-  // if (!hasSetRequiredStxAddressPropForRequestAccountFlow) {
-  //   throw new Error(
-  //     'Must set property `stxAddress` when using `stx_requestAccounts to initiate transaction`'
-  //   );
-  // }
-  return { ...options, network };
+  return {
+    stxAddress: getStxAddress(defaults),
+    ...defaults,
+  };
 }
 
 function encodePostConditions(postConditions: PostCondition[]) {


### PR DESCRIPTION
Per this report in https://github.com/hirosystems/stacks-wallet-web/issues/2906, we found that the active STX address a user authed with wasn't being passed to wallet.

We don't need the `hasAppPrivateKey` check before the `getStxAddress` call for Ledger. This has been removed, so the code is shared between software/ledger wallets, so that the default key is no longer omitted.