### PR TITLE
feat: multiple btc recipients support

### DIFF
--- a/packages/connect/src/transactions/btc.ts
+++ b/packages/connect/src/transactions/btc.ts
@@ -1,6 +1,7 @@
 import { createUnsecuredToken, Json } from 'jsontokens';
-import { BTCTransferOptions, BTCTransferPayload, TransactionTypes } from 'src/types';
-import { getStacksProvider } from 'src/utils';
+import { getDefaults, getStxAddress } from '.';
+import { BtcRecipient, BTCTransferOptions, BTCTransferPayload, TransactionTypes } from '../types';
+import { getStacksProvider } from '../utils';
 
 const openGenericTransactionPopup = async ({
   token,
@@ -25,15 +26,23 @@ const openGenericTransactionPopup = async ({
 };
 
 export function openBTCTransfer(options: BTCTransferOptions): Promise<void> {
-  const { amount, ..._options } = {
+  const { recipients, ..._options } = {
     // todo: do we maybe want userSession, stxAddress, ...?
     // ...getDefaults(options),
     ...options,
   };
 
+  const payLoadRecipients: BtcRecipient[] = [];
+  recipients.forEach(recipient => {
+    payLoadRecipients.push({
+      recipient: recipient.recipient,
+      amount: recipient.amount.toString(10),
+    });
+  });
+
   const payload: Partial<BTCTransferPayload> = {
     ..._options,
-    amount: amount.toString(10),
+    recipients: payLoadRecipients,
     txType: TransactionTypes.BTCTransfer,
   };
 

--- a/packages/connect/src/types/transactions.ts
+++ b/packages/connect/src/types/transactions.ts
@@ -154,8 +154,16 @@ export interface STXTransferPayload extends STXTransferBase {
  * Transaction Popup
  */
 
-export type TransactionOptions = ContractCallOptions | ContractDeployOptions | STXTransferOptions;
-export type TransactionPayload = ContractCallPayload | ContractDeployPayload | STXTransferPayload;
+export type TransactionOptions =
+  | ContractCallOptions
+  | ContractDeployOptions
+  | STXTransferOptions
+  | BTCTransferOptions;
+export type TransactionPayload =
+  | ContractCallPayload
+  | ContractDeployPayload
+  | STXTransferPayload
+  | BTCTransferPayload;
 
 export interface TransactionPopup {
   token: string;
@@ -166,13 +174,16 @@ export interface TransactionPopup {
  * BTC Transfer
  */
 
-export interface BTCTransferOptions extends RegularOptionsBase {
+export interface BtcRecipient {
   recipient: string;
   amount: bigint | number | string;
 }
 
+export interface BTCTransferOptions extends RegularOptionsBase {
+  recipients: BtcRecipient[];
+}
+
 export interface BTCTransferPayload extends BTCTransferOptions {
-  recipient: string;
-  amount: string;
+  recipients: BtcRecipient[];
   txType: TransactionTypes.BTCTransfer;
 }


### PR DESCRIPTION
## Description

Modified the interface to accept an array of recipient addresses and amounts in order to support multiple recipients. Updated BTCTransferOptions and BTCTransferPayload interfaces. 

Link to relevant issues and documentation: #283 
https://github.com/hirosystems/connect/issues/283#issuecomment-1397938096

Example:
Added ability to add multiple recipients when sending a BTC transfer request

```
const recipients = [
      {
        recipient: '2NAm1LPPHQQ8AaLhXSYWrpApoCKcyjNJsjf',
        amount: '20000'
      }
    ];
    await openBTCTransfer(
      {
        recipients: recipients,
        appDetails: {
          name: "My App",
          icon: window.location.origin + "/my-app-logo.svg",
        },
        onCancel: () => {
          alert("Cancelled");
        },
        onFinish: (data) => {
          alert(`Transaction ID: ${data.txId}`);
          alert(`Raw transaction: ${data.txRaw}`);
        }, 
      });

```

For details refer to issue #283 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

