### PR TITLE
feat: allow a custom provider to be passed to Connect methods

### DIFF
--- a/packages/connect-react/src/react/hooks/use-connect.ts
+++ b/packages/connect-react/src/react/hooks/use-connect.ts
@@ -22,6 +22,7 @@ import {
   STXTransferOptions,
   STXTransferRegularOptions,
   STXTransferSponsoredOptions,
+  StacksProvider,
 } from '@stacks/connect';
 import { StructuredDataSignatureRequestOptions } from '@stacks/connect/src/types/structuredDataSignature';
 import { useContext } from 'react';
@@ -36,6 +37,7 @@ const useConnectDispatch = () => {
 };
 
 export const useConnect = () => {
+  // todo: add custom provider injection in connect context
   const { isOpen, isAuthenticating, authData, authOptions, userSession } =
     useContext(ConnectContext);
 
@@ -50,7 +52,11 @@ export const useConnect = () => {
    * @param signIn Whether the user should be sent to sign in
    * @param options
    */
-  const doOpenAuth = (signIn?: boolean, options?: Partial<AuthOptions>) => {
+  const doOpenAuth = (
+    signIn?: boolean,
+    options?: Partial<AuthOptions>,
+    provider?: StacksProvider
+  ) => {
     if (signIn) {
       const _options: AuthOptions = {
         ...authOptions,
@@ -60,7 +66,7 @@ export const useConnect = () => {
         },
         sendToSignIn: true,
       };
-      void authenticate(_options);
+      void authenticate(_options, provider);
       return;
     } else {
       showBlockstackConnect({
@@ -71,79 +77,106 @@ export const useConnect = () => {
     authOptions && doUpdateAuthOptions(authOptions);
   };
 
-  const doAuth = (options: Partial<AuthOptions> = {}) => {
-    void authenticate({
-      ...authOptions,
-      ...options,
-      onFinish: (payload: FinishedAuthData) => {
-        authOptions.onFinish?.(payload);
+  const doAuth = (options: Partial<AuthOptions> = {}, provider?: StacksProvider) => {
+    void authenticate(
+      {
+        ...authOptions,
+        ...options,
+        onFinish: (payload: FinishedAuthData) => {
+          authOptions.onFinish?.(payload);
+        },
       },
-    });
+      provider
+    );
   };
 
-  function doContractCall(options: ContractCallRegularOptions): Promise<void>;
-  function doContractCall(options: ContractCallSponsoredOptions): Promise<void>;
-  function doContractCall(options: ContractCallOptions): Promise<void>;
-  function doContractCall(options: ContractCallOptions) {
-    return openContractCall({
-      ...options,
-      authOrigin: authOptions.authOrigin,
-      appDetails: authOptions.appDetails,
-    });
+  function doContractCall(
+    options: ContractCallOptions | ContractCallRegularOptions | ContractCallSponsoredOptions,
+    provider?: StacksProvider
+  ) {
+    return openContractCall(
+      {
+        ...options,
+        authOrigin: authOptions.authOrigin,
+        appDetails: authOptions.appDetails,
+      },
+      provider
+    );
   }
 
-  function doContractDeploy(options: ContractDeployRegularOptions): Promise<void>;
-  function doContractDeploy(options: ContractDeploySponsoredOptions): Promise<void>;
-  function doContractDeploy(options: ContractDeployOptions): Promise<void>;
-  function doContractDeploy(options: ContractDeployOptions) {
-    return openContractDeploy({
-      ...options,
-      authOrigin: authOptions.authOrigin,
-      appDetails: authOptions.appDetails,
-    });
+  function doContractDeploy(
+    options: ContractDeployOptions | ContractDeployRegularOptions | ContractDeploySponsoredOptions,
+    provider?: StacksProvider
+  ) {
+    return openContractDeploy(
+      {
+        ...options,
+        authOrigin: authOptions.authOrigin,
+        appDetails: authOptions.appDetails,
+      },
+      provider
+    );
   }
 
-  function doSTXTransfer(options: STXTransferRegularOptions): Promise<void>;
-  function doSTXTransfer(options: STXTransferSponsoredOptions): Promise<void>;
-  function doSTXTransfer(options: STXTransferOptions): Promise<void>;
-  function doSTXTransfer(options: STXTransferOptions) {
-    return openSTXTransfer({
-      ...options,
-      authOrigin: authOptions.authOrigin,
-      appDetails: authOptions.appDetails,
-    });
+  function doSTXTransfer(
+    options: STXTransferOptions | STXTransferRegularOptions | STXTransferSponsoredOptions,
+    provider?: StacksProvider
+  ) {
+    return openSTXTransfer(
+      {
+        ...options,
+        authOrigin: authOptions.authOrigin,
+        appDetails: authOptions.appDetails,
+      },
+      provider
+    );
   }
 
-  function doProfileUpdate(options: ProfileUpdateRequestOptions) {
-    return openProfileUpdateRequestPopup({
-      ...options,
-      authOrigin: authOptions.authOrigin,
-      appDetails: authOptions.appDetails,
-    });
+  function doProfileUpdate(options: ProfileUpdateRequestOptions, provider?: StacksProvider) {
+    return openProfileUpdateRequestPopup(
+      {
+        ...options,
+        authOrigin: authOptions.authOrigin,
+        appDetails: authOptions.appDetails,
+      },
+      provider
+    );
   }
 
-  function sign(options: SignatureRequestOptions) {
-    return openSignatureRequestPopup({
-      ...options,
-      authOrigin: authOptions.authOrigin,
-      appDetails: authOptions.appDetails,
-    });
+  function sign(options: SignatureRequestOptions, provider?: StacksProvider) {
+    return openSignatureRequestPopup(
+      {
+        ...options,
+        authOrigin: authOptions.authOrigin,
+        appDetails: authOptions.appDetails,
+      },
+      provider
+    );
   }
 
-  function signStructuredData(options: StructuredDataSignatureRequestOptions) {
-    return openStructuredDataSignatureRequestPopup({
-      ...options,
-      authOrigin: authOptions.authOrigin,
-      appDetails: authOptions.appDetails,
-    });
+  function signStructuredData(
+    options: StructuredDataSignatureRequestOptions,
+    provider?: StacksProvider
+  ) {
+    return openStructuredDataSignatureRequestPopup(
+      {
+        ...options,
+        authOrigin: authOptions.authOrigin,
+        appDetails: authOptions.appDetails,
+      },
+      provider
+    );
   }
 
-  function signPsbt(options: PsbtRequestOptions) {
-    return openPsbtRequestPopup({
-      ...options,
-      authOrigin: authOptions.authOrigin,
-      appDetails: authOptions.appDetails,
-    });
+  function signPsbt(options: PsbtRequestOptions, provider?: StacksProvider) {
+    return openPsbtRequestPopup(
+      {
+        ...options,
+        authOrigin: authOptions.authOrigin,
+        appDetails: authOptions.appDetails,
+      },
+      provider
+    );
   }
 
   return {

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -191,7 +191,7 @@ openStructuredDataSignatureRequestPopup({ ...opts }, HiroWalletProvider);
 ## 🤔 Pitfalls <!-- omit in toc -->
 
 - Connect can currently not set manual nonces, since this is not supported by wallets.
-- For some projects it might be necessary to also install the `regenerator-runtime` package. `npm install --save-dev regenerator-runtime`. This is a build issue of `@stacks/connect` and we are working on a fix.
+- For some projects it might be necessary to also install the `regenerator-runtime` package. `npm install --save-dev regenerator-runtime`. This is a build issue of older versions of `@stacks/connect`.
 
 ## 📚 Method Parameters <!-- omit in toc -->
 

--- a/packages/connect/src/auth.ts
+++ b/packages/connect/src/auth.ts
@@ -1,6 +1,6 @@
 import { AppConfig, UserSession } from '@stacks/auth';
 import { decodeToken } from 'jsontokens';
-import type { AuthOptions, AuthResponsePayload } from './types';
+import type { AuthOptions, AuthResponsePayload, StacksProvider } from './types';
 
 import { getStacksProvider } from './utils';
 
@@ -38,11 +38,11 @@ export const getOrCreateUserSession = (userSession?: UserSession): UserSession =
   return userSession;
 };
 
-export const authenticate = async (authOptions: AuthOptions) => {
-  const provider = getStacksProvider();
-  if (!provider) {
-    throw new Error('Unable to authenticate without Hiro Wallet extension');
-  }
+export const authenticate = async (
+  authOptions: AuthOptions,
+  provider: StacksProvider = getStacksProvider()
+) => {
+  if (!provider) throw new Error('[Connect] No installed Stacks wallet found');
 
   const {
     redirectTo = '/',

--- a/packages/connect/src/bitcoin/psbt.ts
+++ b/packages/connect/src/bitcoin/psbt.ts
@@ -63,18 +63,22 @@ export const makePsbtToken = async (options: PsbtRequestOptions) => {
 
 async function generateTokenAndOpenPopup<T extends PsbtRequestOptions>(
   options: T,
-  makeTokenFn: (options: T) => Promise<string>
+  makeTokenFn: (options: T) => Promise<string>,
+  provider: StacksProvider = getStacksProvider()
 ) {
   const token = await makeTokenFn({
     ...getDefaultPsbtRequestOptions(options),
     ...options,
   } as T);
-  return openPsbtPopup({ token, options });
+  return openPsbtPopup({ token, options }, provider);
 }
 
 /**
  * @experimental
  */
-export function openPsbtRequestPopup(options: PsbtRequestOptions) {
-  return generateTokenAndOpenPopup(options, makePsbtToken);
+export function openPsbtRequestPopup(
+  options: PsbtRequestOptions,
+  provider: StacksProvider = getStacksProvider()
+) {
+  return generateTokenAndOpenPopup(options, makePsbtToken, provider);
 }

--- a/packages/connect/src/bitcoin/psbt.ts
+++ b/packages/connect/src/bitcoin/psbt.ts
@@ -4,6 +4,7 @@ import { createUnsecuredToken, Json, TokenSigner } from 'jsontokens';
 import { getKeys, getUserSession, hasAppPrivateKey } from '../transactions';
 import { PsbtPayload, PsbtPopup, PsbtRequestOptions } from '../types/bitcoin';
 import { getStacksProvider } from '../utils';
+import { StacksProvider } from '../types';
 
 // eslint-disable-next-line @typescript-eslint/require-await
 async function signPayload(payload: PsbtPayload, privateKey: string) {
@@ -25,11 +26,11 @@ export function getDefaultPsbtRequestOptions(options: PsbtRequestOptions) {
   };
 }
 
-async function openPsbtPopup({ token, options }: PsbtPopup) {
-  const provider = getStacksProvider();
-  if (!provider) {
-    throw new Error('Hiro Wallet not installed');
-  }
+async function openPsbtPopup(
+  { token, options }: PsbtPopup,
+  provider: StacksProvider = getStacksProvider()
+) {
+  if (!provider) throw new Error('[Connect] No installed Stacks wallet found');
 
   try {
     const psbtResponse = await provider.psbtRequest(token);

--- a/packages/connect/src/bitcoin/psbt.ts
+++ b/packages/connect/src/bitcoin/psbt.ts
@@ -26,10 +26,7 @@ export function getDefaultPsbtRequestOptions(options: PsbtRequestOptions) {
   };
 }
 
-async function openPsbtPopup(
-  { token, options }: PsbtPopup,
-  provider: StacksProvider = getStacksProvider()
-) {
+async function openPsbtPopup({ token, options }: PsbtPopup, provider: StacksProvider) {
   if (!provider) throw new Error('[Connect] No installed Stacks wallet found');
 
   try {
@@ -64,7 +61,7 @@ export const makePsbtToken = async (options: PsbtRequestOptions) => {
 async function generateTokenAndOpenPopup<T extends PsbtRequestOptions>(
   options: T,
   makeTokenFn: (options: T) => Promise<string>,
-  provider: StacksProvider = getStacksProvider()
+  provider: StacksProvider
 ) {
   const token = await makeTokenFn({
     ...getDefaultPsbtRequestOptions(options),

--- a/packages/connect/src/profile/index.ts
+++ b/packages/connect/src/profile/index.ts
@@ -32,10 +32,8 @@ export function getDefaultProfileUpdateRequestOptions(options: ProfileUpdateRequ
 
 async function openProfileUpdatePopup(
   { token, options }: ProfileUpdatePopup,
-  provider: StacksProvider = getStacksProvider()
+  provider: StacksProvider
 ) {
-  if (!provider) throw new Error('[Connect] No installed Stacks wallet found');
-
   try {
     const profileUpdateResponse = await provider.profileUpdateRequest(token);
     options.onFinish?.(profileUpdateResponse);
@@ -66,7 +64,7 @@ export const makeProfileUpdateToken = async (options: ProfileUpdateRequestOption
 async function generateTokenAndOpenPopup<T extends ProfileUpdateRequestOptions>(
   options: T,
   makeTokenFn: (options: T) => Promise<string>,
-  provider: StacksProvider = getStacksProvider()
+  provider: StacksProvider
 ) {
   const token = await makeTokenFn({
     ...getDefaultProfileUpdateRequestOptions(options),
@@ -79,5 +77,6 @@ export function openProfileUpdateRequestPopup(
   options: ProfileUpdateRequestOptions,
   provider: StacksProvider = getStacksProvider()
 ) {
+  if (!provider) throw new Error('[Connect] No installed Stacks wallet found');
   return generateTokenAndOpenPopup(options, makeProfileUpdateToken, provider);
 }

--- a/packages/connect/src/profile/index.ts
+++ b/packages/connect/src/profile/index.ts
@@ -65,15 +65,19 @@ export const makeProfileUpdateToken = async (options: ProfileUpdateRequestOption
 
 async function generateTokenAndOpenPopup<T extends ProfileUpdateRequestOptions>(
   options: T,
-  makeTokenFn: (options: T) => Promise<string>
+  makeTokenFn: (options: T) => Promise<string>,
+  provider: StacksProvider = getStacksProvider()
 ) {
   const token = await makeTokenFn({
     ...getDefaultProfileUpdateRequestOptions(options),
     ...options,
   } as T);
-  return openProfileUpdatePopup({ token, options });
+  return openProfileUpdatePopup({ token, options }, provider);
 }
 
-export function openProfileUpdateRequestPopup(options: ProfileUpdateRequestOptions) {
-  return generateTokenAndOpenPopup(options, makeProfileUpdateToken);
+export function openProfileUpdateRequestPopup(
+  options: ProfileUpdateRequestOptions,
+  provider: StacksProvider = getStacksProvider()
+) {
+  return generateTokenAndOpenPopup(options, makeProfileUpdateToken, provider);
 }

--- a/packages/connect/src/profile/index.ts
+++ b/packages/connect/src/profile/index.ts
@@ -1,7 +1,12 @@
 import { StacksTestnet } from '@stacks/network';
 import { createUnsecuredToken, Json, TokenSigner } from 'jsontokens';
 import { getKeys, getUserSession, hasAppPrivateKey } from '../transactions';
-import { ProfileUpdatePayload, ProfileUpdatePopup, ProfileUpdateRequestOptions } from '../types';
+import {
+  ProfileUpdatePayload,
+  ProfileUpdatePopup,
+  ProfileUpdateRequestOptions,
+  StacksProvider,
+} from '../types';
 
 import { getStacksProvider } from '../utils';
 
@@ -25,11 +30,11 @@ export function getDefaultProfileUpdateRequestOptions(options: ProfileUpdateRequ
   };
 }
 
-async function openProfileUpdatePopup({ token, options }: ProfileUpdatePopup) {
-  const provider = getStacksProvider();
-  if (!provider) {
-    throw new Error('Hiro Wallet not installed.');
-  }
+async function openProfileUpdatePopup(
+  { token, options }: ProfileUpdatePopup,
+  provider: StacksProvider = getStacksProvider()
+) {
+  if (!provider) throw new Error('[Connect] No installed Stacks wallet found');
 
   try {
     const profileUpdateResponse = await provider.profileUpdateRequest(token);

--- a/packages/connect/src/signature/index.ts
+++ b/packages/connect/src/signature/index.ts
@@ -85,15 +85,19 @@ export const signMessage = async (options: SignatureRequestOptions) => {
 
 async function generateTokenAndOpenPopup<T extends SignatureOptions>(
   options: T,
-  makeTokenFn: (options: T) => Promise<string>
+  makeTokenFn: (options: T) => Promise<string>,
+  provider: StacksProvider = getStacksProvider()
 ) {
   const token = await makeTokenFn({
     ...getDefaultSignatureRequestOptions(options),
     ...options,
   } as T);
-  return openSignaturePopup({ token, options });
+  return openSignaturePopup({ token, options }, provider);
 }
 
-export function openSignatureRequestPopup(options: SignatureRequestOptions) {
-  return generateTokenAndOpenPopup(options, signMessage);
+export function openSignatureRequestPopup(
+  options: SignatureRequestOptions,
+  provider: StacksProvider = getStacksProvider()
+) {
+  return generateTokenAndOpenPopup(options, signMessage, provider);
 }

--- a/packages/connect/src/signature/index.ts
+++ b/packages/connect/src/signature/index.ts
@@ -10,6 +10,7 @@ import {
   SignatureRequestOptions,
 } from '../types/signature';
 import { getStacksProvider } from '../utils';
+import { StacksProvider } from '../types';
 
 function getStxAddress(options: CommonSignatureRequestOptions) {
   const { userSession, network } = options;
@@ -45,11 +46,11 @@ export function getDefaultSignatureRequestOptions(options: CommonSignatureReques
   };
 }
 
-async function openSignaturePopup({ token, options }: SignaturePopup) {
-  const provider = getStacksProvider();
-  if (!provider) {
-    throw new Error('Hiro Wallet not installed.');
-  }
+async function openSignaturePopup(
+  { token, options }: SignaturePopup,
+  provider: StacksProvider = getStacksProvider()
+) {
+  if (!provider) throw new Error('[Connect] No installed Stacks wallet found');
 
   try {
     const signatureResponse = await provider.signatureRequest(token);

--- a/packages/connect/src/signature/index.ts
+++ b/packages/connect/src/signature/index.ts
@@ -46,12 +46,7 @@ export function getDefaultSignatureRequestOptions(options: CommonSignatureReques
   };
 }
 
-async function openSignaturePopup(
-  { token, options }: SignaturePopup,
-  provider: StacksProvider = getStacksProvider()
-) {
-  if (!provider) throw new Error('[Connect] No installed Stacks wallet found');
-
+async function openSignaturePopup({ token, options }: SignaturePopup, provider: StacksProvider) {
   try {
     const signatureResponse = await provider.signatureRequest(token);
     options.onFinish?.(signatureResponse);
@@ -86,7 +81,7 @@ export const signMessage = async (options: SignatureRequestOptions) => {
 async function generateTokenAndOpenPopup<T extends SignatureOptions>(
   options: T,
   makeTokenFn: (options: T) => Promise<string>,
-  provider: StacksProvider = getStacksProvider()
+  provider: StacksProvider
 ) {
   const token = await makeTokenFn({
     ...getDefaultSignatureRequestOptions(options),
@@ -99,5 +94,6 @@ export function openSignatureRequestPopup(
   options: SignatureRequestOptions,
   provider: StacksProvider = getStacksProvider()
 ) {
+  if (!provider) throw new Error('[Connect] No installed Stacks wallet found');
   return generateTokenAndOpenPopup(options, signMessage, provider);
 }

--- a/packages/connect/src/signature/structuredData.ts
+++ b/packages/connect/src/signature/structuredData.ts
@@ -14,13 +14,14 @@ import { StacksProvider } from '../types';
 
 async function generateTokenAndOpenPopup<T extends StructuredDataSignatureOptions>(
   options: T,
-  makeTokenFn: (options: T) => Promise<string>
+  makeTokenFn: (options: T) => Promise<string>,
+  provider: StacksProvider = getStacksProvider()
 ) {
   const token = await makeTokenFn({
     ...getDefaultSignatureRequestOptions(options),
     ...options,
   } as T);
-  return openStructuredDataSignaturePopup({ token, options });
+  return openStructuredDataSignaturePopup({ token, options }, provider);
 }
 
 function parseUnserializableBigIntValues(payload: any) {
@@ -70,7 +71,8 @@ async function openStructuredDataSignaturePopup(
 }
 
 export function openStructuredDataSignatureRequestPopup(
-  options: StructuredDataSignatureRequestOptions
+  options: StructuredDataSignatureRequestOptions,
+  provider: StacksProvider = getStacksProvider()
 ) {
-  return generateTokenAndOpenPopup(options, signStructuredMessage);
+  return generateTokenAndOpenPopup(options, signStructuredMessage, provider);
 }

--- a/packages/connect/src/signature/structuredData.ts
+++ b/packages/connect/src/signature/structuredData.ts
@@ -10,6 +10,7 @@ import {
   StructuredDataSignatureRequestOptions,
 } from '../types/structuredDataSignature';
 import { getStacksProvider } from '../utils';
+import { StacksProvider } from '../types';
 
 async function generateTokenAndOpenPopup<T extends StructuredDataSignatureOptions>(
   options: T,
@@ -52,11 +53,11 @@ export async function signStructuredMessage(options: StructuredDataSignatureRequ
   return createUnsecuredToken(parseUnserializableBigIntValues(options));
 }
 
-async function openStructuredDataSignaturePopup({ token, options }: StructuredDataSignaturePopup) {
-  const provider = getStacksProvider();
-  if (!provider) {
-    throw new Error('Hiro Wallet not installed.');
-  }
+async function openStructuredDataSignaturePopup(
+  { token, options }: StructuredDataSignaturePopup,
+  provider: StacksProvider = getStacksProvider()
+) {
+  if (!provider) throw new Error('[Connect] No installed Stacks wallet found');
 
   try {
     const signatureResponse = await provider.structuredDataSignatureRequest(token);

--- a/packages/connect/src/signature/structuredData.ts
+++ b/packages/connect/src/signature/structuredData.ts
@@ -15,7 +15,7 @@ import { StacksProvider } from '../types';
 async function generateTokenAndOpenPopup<T extends StructuredDataSignatureOptions>(
   options: T,
   makeTokenFn: (options: T) => Promise<string>,
-  provider: StacksProvider = getStacksProvider()
+  provider: StacksProvider
 ) {
   const token = await makeTokenFn({
     ...getDefaultSignatureRequestOptions(options),
@@ -56,10 +56,8 @@ export async function signStructuredMessage(options: StructuredDataSignatureRequ
 
 async function openStructuredDataSignaturePopup(
   { token, options }: StructuredDataSignaturePopup,
-  provider: StacksProvider = getStacksProvider()
+  provider: StacksProvider
 ) {
-  if (!provider) throw new Error('[Connect] No installed Stacks wallet found');
-
   try {
     const signatureResponse = await provider.structuredDataSignatureRequest(token);
 
@@ -74,5 +72,6 @@ export function openStructuredDataSignatureRequestPopup(
   options: StructuredDataSignatureRequestOptions,
   provider: StacksProvider = getStacksProvider()
 ) {
+  if (!provider) throw new Error('[Connect] No installed Stacks wallet found');
   return generateTokenAndOpenPopup(options, signStructuredMessage, provider);
 }

--- a/packages/connect/src/transactions/index.ts
+++ b/packages/connect/src/transactions/index.ts
@@ -30,6 +30,7 @@ import {
   TransactionTypes,
 } from '../types/transactions';
 import { getStacksProvider } from '../utils';
+import { StacksProvider } from '../types';
 
 // TODO extract out of transactions
 export const getUserSession = (_userSession?: UserSession) => {
@@ -113,11 +114,11 @@ function createUnsignedTransactionPayload(payload: Partial<TransactionPayload>) 
   return createUnsecuredToken({ ...payload, postConditions } as unknown as Json);
 }
 
-const openTransactionPopup = async ({ token, options }: TransactionPopup) => {
-  const provider = getStacksProvider();
-  if (!provider) {
-    throw new Error('Hiro Wallet not installed');
-  }
+const openTransactionPopup = async (
+  { token, options }: TransactionPopup,
+  provider: StacksProvider = getStacksProvider()
+) => {
+  if (!provider) throw new Error('[Connect] No installed Stacks wallet found');
 
   try {
     const txResponse = await provider.transactionRequest(token);

--- a/packages/connect/src/transactions/index.ts
+++ b/packages/connect/src/transactions/index.ts
@@ -116,10 +116,8 @@ function createUnsignedTransactionPayload(payload: Partial<TransactionPayload>) 
 
 const openTransactionPopup = async (
   { token, options }: TransactionPopup,
-  provider: StacksProvider = getStacksProvider()
+  provider: StacksProvider
 ) => {
-  if (!provider) throw new Error('[Connect] No installed Stacks wallet found');
-
   try {
     const txResponse = await provider.transactionRequest(token);
     const { txRaw } = txResponse;
@@ -223,7 +221,7 @@ export const makeSTXTransferToken = async (options: STXTransferOptions) => {
 async function generateTokenAndOpenPopup<T extends TransactionOptions>(
   options: T,
   makeTokenFn: (options: T) => Promise<string>,
-  provider: StacksProvider = getStacksProvider()
+  provider: StacksProvider
 ) {
   const token = await makeTokenFn({
     ...getDefaults(options),
@@ -236,6 +234,7 @@ export function openContractCall(
   options: ContractCallOptions | ContractCallRegularOptions | ContractCallSponsoredOptions,
   provider: StacksProvider = getStacksProvider()
 ) {
+  if (!provider) throw new Error('[Connect] No installed Stacks wallet found');
   return generateTokenAndOpenPopup(options, makeContractCallToken, provider);
 }
 
@@ -243,6 +242,7 @@ export function openContractDeploy(
   options: ContractDeployOptions | ContractDeployRegularOptions | ContractDeploySponsoredOptions,
   provider: StacksProvider = getStacksProvider()
 ) {
+  if (!provider) throw new Error('[Connect] No installed Stacks wallet found');
   return generateTokenAndOpenPopup(options, makeContractDeployToken, provider);
 }
 
@@ -250,5 +250,6 @@ export function openSTXTransfer(
   options: STXTransferOptions | STXTransferRegularOptions | STXTransferSponsoredOptions,
   provider: StacksProvider = getStacksProvider()
 ) {
+  if (!provider) throw new Error('[Connect] No installed Stacks wallet found');
   return generateTokenAndOpenPopup(options, makeSTXTransferToken, provider);
 }

--- a/packages/connect/src/transactions/index.ts
+++ b/packages/connect/src/transactions/index.ts
@@ -222,32 +222,33 @@ export const makeSTXTransferToken = async (options: STXTransferOptions) => {
 
 async function generateTokenAndOpenPopup<T extends TransactionOptions>(
   options: T,
-  makeTokenFn: (options: T) => Promise<string>
+  makeTokenFn: (options: T) => Promise<string>,
+  provider: StacksProvider = getStacksProvider()
 ) {
   const token = await makeTokenFn({
     ...getDefaults(options),
     ...options,
   } as T);
-  return openTransactionPopup({ token, options });
+  return openTransactionPopup({ token, options }, provider);
 }
 
-export function openContractCall(options: ContractCallRegularOptions): Promise<void>;
-export function openContractCall(options: ContractCallSponsoredOptions): Promise<void>;
-export function openContractCall(options: ContractCallOptions): Promise<void>;
-export function openContractCall(options: ContractCallOptions) {
-  return generateTokenAndOpenPopup(options, makeContractCallToken);
+export function openContractCall(
+  options: ContractCallOptions | ContractCallRegularOptions | ContractCallSponsoredOptions,
+  provider: StacksProvider = getStacksProvider()
+) {
+  return generateTokenAndOpenPopup(options, makeContractCallToken, provider);
 }
 
-export function openContractDeploy(options: ContractDeployRegularOptions): Promise<void>;
-export function openContractDeploy(options: ContractDeploySponsoredOptions): Promise<void>;
-export function openContractDeploy(options: ContractDeployOptions): Promise<void>;
-export function openContractDeploy(options: ContractDeployOptions) {
-  return generateTokenAndOpenPopup(options, makeContractDeployToken);
+export function openContractDeploy(
+  options: ContractDeployOptions | ContractDeployRegularOptions | ContractDeploySponsoredOptions,
+  provider: StacksProvider = getStacksProvider()
+) {
+  return generateTokenAndOpenPopup(options, makeContractDeployToken, provider);
 }
 
-export function openSTXTransfer(options: STXTransferRegularOptions): Promise<void>;
-export function openSTXTransfer(options: STXTransferSponsoredOptions): Promise<void>;
-export function openSTXTransfer(options: STXTransferOptions): Promise<void>;
-export function openSTXTransfer(options: STXTransferOptions) {
-  return generateTokenAndOpenPopup(options, makeSTXTransferToken);
+export function openSTXTransfer(
+  options: STXTransferOptions | STXTransferRegularOptions | STXTransferSponsoredOptions,
+  provider: StacksProvider = getStacksProvider()
+) {
+  return generateTokenAndOpenPopup(options, makeSTXTransferToken, provider);
 }

--- a/packages/connect/src/ui.ts
+++ b/packages/connect/src/ui.ts
@@ -2,12 +2,17 @@ import { authenticate } from './auth';
 import type { AuthOptions } from './types/auth';
 import { defineCustomElements } from '@stacks/connect-ui/loader';
 import { getStacksProvider } from './utils';
+import { StacksProvider } from './types';
 
-export const showConnect = (authOptions: AuthOptions) => {
-  if (getStacksProvider()) {
+export const showConnect = (
+  authOptions: AuthOptions,
+  provider: StacksProvider = getStacksProvider()
+) => {
+  if (provider) {
     void authenticate(authOptions);
     return;
   }
+
   if (typeof window !== undefined) {
     void defineCustomElements(window);
     const element = document.createElement('connect-modal');

--- a/packages/connect/src/ui.ts
+++ b/packages/connect/src/ui.ts
@@ -9,7 +9,7 @@ export const showConnect = (
   provider: StacksProvider = getStacksProvider()
 ) => {
   if (provider) {
-    void authenticate(authOptions);
+    void authenticate(authOptions, provider);
     return;
   }
 


### PR DESCRIPTION
> This PR was published to npm with the alpha versions:
> - connect `npm install @stacks/connect@7.3.2-alpha.111be12.0 --save-exact`
> - connect-react `npm install @stacks/connect-react@22.1.2-alpha.111be12.0 --save-exact`
> - connect-ui `npm install @stacks/connect-ui@6.1.2-alpha.111be12.0 --save-exact`<!-- Sticky Header Marker -->

### Description

Allow a custom `StacksProvider` object to be passed into most Connect methods.

- Attempt at making this issue better: https://github.com/hirosystems/connect/issues/325

- [ ] Should the provider be a part of the options, or does this separate second param make more sense?

### Example
```ts
import { authenticate } from '@stacks/connect';

// This will open only the Hiro Wallet
authenticate({ ...normalAuthOptions }, HiroWalletProvider); // <---
```


## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

