### PR TITLE
refactor: sighash types to match btckit api

### DIFF
--- a/.changeset/eighty-taxis-repeat.md
+++ b/.changeset/eighty-taxis-repeat.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Updates the SignatureHash type to include all possible types.

--- a/packages/connect/src/types/bitcoin.ts
+++ b/packages/connect/src/types/bitcoin.ts
@@ -3,14 +3,21 @@ import { StacksNetwork } from '@stacks/network';
 
 import { AuthOptions } from './auth';
 
-// Taken from @scure/btc-signer
-// https://github.com/paulmillr/scure-btc-signer
+/**
+ * ALL           -- all inputs, all outputs
+ * NONE          -- all inputs, no outputs
+ * SINGLE        -- all inputs, one output of the same index
+ * ALL + ANYONE  -- one input, all outputs
+ * NONE + ANYONE -- one input, no outputs
+ * SINGLE        -- one inputs, one output of the same index
+ */
 export enum SignatureHash {
-  DEFAULT = 0,
-  ALL = 1,
-  NONE = 2,
-  SINGLE = 3,
-  ANYONECANPAY = 0x80,
+  ALL = 0x01,
+  NONE = 0x02,
+  SINGLE = 0x03,
+  ALL_ANYONECANPAY = 0x81,
+  NONE_ANYONECANPAY = 0x82,
+  SINGLE_ANYONECANPAY = 0x83,
 }
 
 export interface PsbtData {


### PR DESCRIPTION
> This PR was published to npm with the alpha versions:
> - connect `npm install @stacks/connect@7.3.2-alpha.455575e.0 --save-exact`
> - connect-react `npm install @stacks/connect-react@22.1.2-alpha.455575e.0 --save-exact`
> - connect-ui `npm install @stacks/connect-ui@6.1.2-alpha.455575e.0 --save-exact`<!-- Sticky Header Marker -->

This PR refactors the `signPsbt` api `allowedSighash` types to be inclusive of all possible.

Ref changes in btckit: [refactor/sighash-types](https://github.com/btckit-org/btckit/pull/6)
