### PR TITLE
feat: allow transaction as hex for signing

### DIFF
--- a/packages/connect-react/src/react/hooks/use-connect.ts
+++ b/packages/connect-react/src/react/hooks/use-connect.ts
@@ -24,7 +24,7 @@ import {
   STXTransferRegularOptions,
   STXTransferSponsoredOptions,
   StacksProvider,
-  SignTransactionHexOptions,
+  SignTransactionOptions,
 } from '@stacks/connect';
 import { StructuredDataSignatureRequestOptions } from '@stacks/connect/src/types/structuredDataSignature';
 import { useContext } from 'react';
@@ -145,7 +145,7 @@ export const useConnect = () => {
     );
   }
 
-  function doSignTransactionHex(options: SignTransactionHexOptions, provider?: StacksProvider) {
+  function doSignTransaction(options: SignTransactionOptions, provider?: StacksProvider) {
     return openSignTransaction(
       {
         ...options,
@@ -204,7 +204,7 @@ export const useConnect = () => {
     doContractCall,
     doContractDeploy,
     doSTXTransfer,
-    doSignTransactionHex,
+    doSignTransaction,
     doProfileUpdate,
     sign,
     signStructuredData,

--- a/packages/connect-react/src/react/hooks/use-connect.ts
+++ b/packages/connect-react/src/react/hooks/use-connect.ts
@@ -10,7 +10,7 @@ import {
   FinishedAuthData,
   openContractCall,
   openContractDeploy,
-  openSignHexTransaction,
+  openSignTransactionHex,
   openProfileUpdateRequestPopup,
   openPsbtRequestPopup,
   openSignatureRequestPopup,
@@ -24,7 +24,7 @@ import {
   STXTransferRegularOptions,
   STXTransferSponsoredOptions,
   StacksProvider,
-  SignHexTransactionOptions,
+  SignTransactionHexOptions,
 } from '@stacks/connect';
 import { StructuredDataSignatureRequestOptions } from '@stacks/connect/src/types/structuredDataSignature';
 import { useContext } from 'react';
@@ -145,8 +145,8 @@ export const useConnect = () => {
     );
   }
 
-  function doSignHexTransaction(options: SignHexTransactionOptions, provider?: StacksProvider) {
-    return openSignHexTransaction(
+  function doSignTransactionHex(options: SignTransactionHexOptions, provider?: StacksProvider) {
+    return openSignTransactionHex(
       {
         ...options,
         authOrigin: authOptions.authOrigin,
@@ -204,7 +204,7 @@ export const useConnect = () => {
     doContractCall,
     doContractDeploy,
     doSTXTransfer,
-    doSignHexTransaction,
+    doSignTransactionHex,
     doProfileUpdate,
     sign,
     signStructuredData,

--- a/packages/connect-react/src/react/hooks/use-connect.ts
+++ b/packages/connect-react/src/react/hooks/use-connect.ts
@@ -10,6 +10,7 @@ import {
   FinishedAuthData,
   openContractCall,
   openContractDeploy,
+  openSignHexTransaction,
   openProfileUpdateRequestPopup,
   openPsbtRequestPopup,
   openSignatureRequestPopup,
@@ -23,6 +24,7 @@ import {
   STXTransferRegularOptions,
   STXTransferSponsoredOptions,
   StacksProvider,
+  SignHexTransactionOptions,
 } from '@stacks/connect';
 import { StructuredDataSignatureRequestOptions } from '@stacks/connect/src/types/structuredDataSignature';
 import { useContext } from 'react';
@@ -143,6 +145,17 @@ export const useConnect = () => {
     );
   }
 
+  function doSignHexTransaction(options: SignHexTransactionOptions, provider?: StacksProvider) {
+    return openSignHexTransaction(
+      {
+        ...options,
+        authOrigin: authOptions.authOrigin,
+        appDetails: authOptions.appDetails,
+      },
+      provider
+    );
+  }
+
   function sign(options: SignatureRequestOptions, provider?: StacksProvider) {
     return openSignatureRequestPopup(
       {
@@ -191,6 +204,7 @@ export const useConnect = () => {
     doContractCall,
     doContractDeploy,
     doSTXTransfer,
+    doSignHexTransaction,
     doProfileUpdate,
     sign,
     signStructuredData,

--- a/packages/connect-react/src/react/hooks/use-connect.ts
+++ b/packages/connect-react/src/react/hooks/use-connect.ts
@@ -10,7 +10,7 @@ import {
   FinishedAuthData,
   openContractCall,
   openContractDeploy,
-  openSignTransactionHex,
+  openSignTransaction,
   openProfileUpdateRequestPopup,
   openPsbtRequestPopup,
   openSignatureRequestPopup,
@@ -146,7 +146,7 @@ export const useConnect = () => {
   }
 
   function doSignTransactionHex(options: SignTransactionHexOptions, provider?: StacksProvider) {
-    return openSignTransactionHex(
+    return openSignTransaction(
       {
         ...options,
         authOrigin: authOptions.authOrigin,

--- a/packages/connect/src/transactions/index.ts
+++ b/packages/connect/src/transactions/index.ts
@@ -19,8 +19,8 @@ import {
   ContractDeployRegularOptions,
   ContractDeploySponsoredOptions,
   FinishedTxPayload,
-  SignTransactionHexOptions,
-  SignTransactionHexPayload,
+  SignTransactionOptions,
+  SignTransactionPayload,
   SponsoredFinishedTxPayload,
   STXTransferOptions,
   STXTransferPayload,
@@ -220,12 +220,12 @@ export const makeSTXTransferToken = async (options: STXTransferOptions) => {
   return createUnsignedTransactionPayload(payload);
 };
 
-export const makeSignTransactionHex = async (options: SignTransactionHexOptions) => {
+export const makeSignTransaction = async (options: SignTransactionOptions) => {
   const { txHex, appDetails, userSession, ..._options } = options;
 
   if (hasAppPrivateKey(userSession)) {
     const { privateKey, publicKey } = getKeys(userSession);
-    const payload: SignTransactionHexPayload = {
+    const payload: SignTransactionPayload = {
       ..._options,
       txHex,
       publicKey,
@@ -234,7 +234,7 @@ export const makeSignTransactionHex = async (options: SignTransactionHexOptions)
     return signPayload(payload, privateKey);
   }
 
-  const payload: Partial<SignTransactionHexOptions> = {
+  const payload: Partial<SignTransactionOptions> = {
     ..._options,
     txHex,
   };
@@ -279,9 +279,9 @@ export function openSTXTransfer(
 }
 
 export function openSignTransaction(
-  options: SignTransactionHexOptions,
+  options: SignTransactionOptions,
   provider: StacksProvider = getStacksProvider()
 ) {
   if (!provider) throw new Error('[Connect] No installed Stacks wallet found');
-  return generateTokenAndOpenPopup(options, makeSignTransactionHex, provider);
+  return generateTokenAndOpenPopup(options, makeSignTransaction, provider);
 }

--- a/packages/connect/src/transactions/index.ts
+++ b/packages/connect/src/transactions/index.ts
@@ -221,13 +221,13 @@ export const makeSTXTransferToken = async (options: STXTransferOptions) => {
 };
 
 export const makeSignTransactionHex = async (options: SignTransactionHexOptions) => {
-  const { txRaw, appDetails, userSession, ..._options } = options;
+  const { txHex, appDetails, userSession, ..._options } = options;
 
   if (hasAppPrivateKey(userSession)) {
     const { privateKey, publicKey } = getKeys(userSession);
     const payload: SignTransactionHexPayload = {
       ..._options,
-      txRaw,
+      txHex,
       publicKey,
     };
     if (appDetails) payload.appDetails = appDetails;
@@ -236,7 +236,7 @@ export const makeSignTransactionHex = async (options: SignTransactionHexOptions)
 
   const payload: Partial<SignTransactionHexOptions> = {
     ..._options,
-    txRaw,
+    txHex,
   };
   if (appDetails) payload.appDetails = appDetails;
   return createUnsignedTransactionPayload(payload);
@@ -278,7 +278,7 @@ export function openSTXTransfer(
   return generateTokenAndOpenPopup(options, makeSTXTransferToken, provider);
 }
 
-export function openSignTransactionHex(
+export function openSignTransaction(
   options: SignTransactionHexOptions,
   provider: StacksProvider = getStacksProvider()
 ) {

--- a/packages/connect/src/transactions/index.ts
+++ b/packages/connect/src/transactions/index.ts
@@ -19,8 +19,8 @@ import {
   ContractDeployRegularOptions,
   ContractDeploySponsoredOptions,
   FinishedTxPayload,
-  SignHexTransactionOptions,
-  SignHexTransactionPayload,
+  SignTransactionHexOptions,
+  SignTransactionHexPayload,
   SponsoredFinishedTxPayload,
   STXTransferOptions,
   STXTransferPayload,
@@ -220,12 +220,12 @@ export const makeSTXTransferToken = async (options: STXTransferOptions) => {
   return createUnsignedTransactionPayload(payload);
 };
 
-export const makeSignHexTransaction = async (options: SignHexTransactionOptions) => {
+export const makeSignTransactionHex = async (options: SignTransactionHexOptions) => {
   const { txRaw, appDetails, userSession, ..._options } = options;
 
   if (hasAppPrivateKey(userSession)) {
     const { privateKey, publicKey } = getKeys(userSession);
-    const payload: SignHexTransactionPayload = {
+    const payload: SignTransactionHexPayload = {
       ..._options,
       txRaw,
       publicKey,
@@ -234,7 +234,7 @@ export const makeSignHexTransaction = async (options: SignHexTransactionOptions)
     return signPayload(payload, privateKey);
   }
 
-  const payload: Partial<SignHexTransactionOptions> = {
+  const payload: Partial<SignTransactionHexOptions> = {
     ..._options,
     txRaw,
   };
@@ -278,10 +278,10 @@ export function openSTXTransfer(
   return generateTokenAndOpenPopup(options, makeSTXTransferToken, provider);
 }
 
-export function openSignHexTransaction(
-  options: SignHexTransactionOptions,
+export function openSignTransactionHex(
+  options: SignTransactionHexOptions,
   provider: StacksProvider = getStacksProvider()
 ) {
   if (!provider) throw new Error('[Connect] No installed Stacks wallet found');
-  return generateTokenAndOpenPopup(options, makeSignHexTransaction, provider);
+  return generateTokenAndOpenPopup(options, makeSignTransactionHex, provider);
 }

--- a/packages/connect/src/types/transactions.ts
+++ b/packages/connect/src/types/transactions.ts
@@ -28,7 +28,7 @@ export interface TxBase {
   nonce?: number;
 }
 
-export interface SignTransactionHexBase {
+export interface SignTransactionBase {
   appDetails?: AuthOptions['appDetails'];
   network?: StacksNetwork;
   attachment?: string;
@@ -171,31 +171,31 @@ export type TransactionOptions =
   | ContractCallOptions
   | ContractDeployOptions
   | STXTransferOptions
-  | SignTransactionHexOptions;
+  | SignTransactionOptions;
 export type TransactionPayload =
   | ContractCallPayload
   | ContractDeployPayload
   | STXTransferPayload
-  | SignTransactionHexPayload;
+  | SignTransactionPayload;
 
 export interface TransactionPopup {
   token: string;
   options: TransactionOptions;
 }
 
-export interface SignTransactionHexOptionBase extends SignTransactionHexBase, OptionsBase {
-  onFinish?: SignTransactionHexFinished;
+export interface SignTransactionOptionBase extends SignTransactionBase, OptionsBase {
+  onFinish?: SignTransactionFinished;
   onCancel?: Canceled;
 }
 
-export interface SignTransactionHexPayload extends SignTransactionHexBase {
+export interface SignTransactionPayload extends SignTransactionBase {
   publicKey: string;
 }
 
-export type SignTransactionHexFinished = (data: SignTransactionHexFinishedTxData) => void;
+export type SignTransactionFinished = (data: SignTransactionFinishedTxData) => void;
 
-export type SignTransactionHexOptions = SignTransactionHexOptionBase;
+export type SignTransactionOptions = SignTransactionOptionBase;
 
-export interface SignTransactionHexFinishedTxData {
+export interface SignTransactionFinishedTxData {
   stacksTransaction: StacksTransaction;
 }

--- a/packages/connect/src/types/transactions.ts
+++ b/packages/connect/src/types/transactions.ts
@@ -37,7 +37,7 @@ export interface SignTransactionHexBase {
    * This is set by default if a `userSession` option is provided.
    */
   stxAddress?: string;
-  txRaw: string;
+  txHex: string;
   /** @deprecated `unused - only included for compatibility with other transaction types` */
   postConditions?: (string | PostCondition)[];
 }

--- a/packages/connect/src/types/transactions.ts
+++ b/packages/connect/src/types/transactions.ts
@@ -28,6 +28,20 @@ export interface TxBase {
   nonce?: number;
 }
 
+export interface SignHexTransactionBase {
+  appDetails?: AuthOptions['appDetails'];
+  network?: StacksNetwork;
+  attachment?: string;
+  /**
+   * Provide wallets with a suggested account to sign this transaction with.
+   * This is set by default if a `userSession` option is provided.
+   */
+  stxAddress?: string;
+  txRaw: string;
+  /** @deprecated `unused - only included for compatibility with other transaction types` */
+  postConditions?: (string | PostCondition)[];
+}
+
 export interface SponsoredFinishedTxPayload {
   txRaw: string;
 }
@@ -153,10 +167,35 @@ export interface STXTransferPayload extends STXTransferBase {
  * Transaction Popup
  */
 
-export type TransactionOptions = ContractCallOptions | ContractDeployOptions | STXTransferOptions;
-export type TransactionPayload = ContractCallPayload | ContractDeployPayload | STXTransferPayload;
+export type TransactionOptions =
+  | ContractCallOptions
+  | ContractDeployOptions
+  | STXTransferOptions
+  | SignHexTransactionOptions;
+export type TransactionPayload =
+  | ContractCallPayload
+  | ContractDeployPayload
+  | STXTransferPayload
+  | SignHexTransactionPayload;
 
 export interface TransactionPopup {
   token: string;
   options: TransactionOptions;
+}
+
+export interface SignHexTransactionOptionBase extends SignHexTransactionBase, OptionsBase {
+  onFinish?: SignHexTransactionFinished;
+  onCancel?: Canceled;
+}
+
+export interface SignHexTransactionPayload extends SignHexTransactionBase {
+  publicKey: string;
+}
+
+export type SignHexTransactionFinished = (data: SignHexTransactionFinishedTxData) => void;
+
+export type SignHexTransactionOptions = SignHexTransactionOptionBase;
+
+export interface SignHexTransactionFinishedTxData {
+  stacksTransaction: StacksTransaction;
 }

--- a/packages/connect/src/types/transactions.ts
+++ b/packages/connect/src/types/transactions.ts
@@ -28,7 +28,7 @@ export interface TxBase {
   nonce?: number;
 }
 
-export interface SignHexTransactionBase {
+export interface SignTransactionHexBase {
   appDetails?: AuthOptions['appDetails'];
   network?: StacksNetwork;
   attachment?: string;
@@ -171,31 +171,31 @@ export type TransactionOptions =
   | ContractCallOptions
   | ContractDeployOptions
   | STXTransferOptions
-  | SignHexTransactionOptions;
+  | SignTransactionHexOptions;
 export type TransactionPayload =
   | ContractCallPayload
   | ContractDeployPayload
   | STXTransferPayload
-  | SignHexTransactionPayload;
+  | SignTransactionHexPayload;
 
 export interface TransactionPopup {
   token: string;
   options: TransactionOptions;
 }
 
-export interface SignHexTransactionOptionBase extends SignHexTransactionBase, OptionsBase {
-  onFinish?: SignHexTransactionFinished;
+export interface SignTransactionHexOptionBase extends SignTransactionHexBase, OptionsBase {
+  onFinish?: SignTransactionHexFinished;
   onCancel?: Canceled;
 }
 
-export interface SignHexTransactionPayload extends SignHexTransactionBase {
+export interface SignTransactionHexPayload extends SignTransactionHexBase {
   publicKey: string;
 }
 
-export type SignHexTransactionFinished = (data: SignHexTransactionFinishedTxData) => void;
+export type SignTransactionHexFinished = (data: SignTransactionHexFinishedTxData) => void;
 
-export type SignHexTransactionOptions = SignHexTransactionOptionBase;
+export type SignTransactionHexOptions = SignTransactionHexOptionBase;
 
-export interface SignHexTransactionFinishedTxData {
+export interface SignTransactionHexFinishedTxData {
   stacksTransaction: StacksTransaction;
 }


### PR DESCRIPTION
## Description

Currently, it is not possible to sign a multisig transaction through Stacks wallets using Stacks.js. I added this functionality for Hiro Wallet with [this pull request](https://github.com/hirosystems/wallet/pull/4048). This PR is an initial draft to extend this functionality for Xverse and other potential wallets within Stacks.

This code adds new methods to sign a transaction hex, which should be parsed and displayed on the wallet side. With this method, it will be possible to sign any transaction on Stacks, including sponsored and multisig ones.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
This is not a breaking change.

## Are documentation updates required?
New hex transaction signing methods like `openSignTransaction` and `doSignTransaction` require documentation updates.

## Testing information
Tests are required on the wallet side to check the correctness of the new methods.

## Checklist
- [x] Code is commented on where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `yarn lerna run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @hstove or @kyranjamie or @aulneau for review
