### PR TITLE
refactor: make showConnect not persist, less breaking

### DIFF
--- a/packages/connect-ui/src/components.d.ts
+++ b/packages/connect-ui/src/components.d.ts
@@ -11,6 +11,7 @@ export namespace Components {
         "callback": Function;
         "defaultProviders": WebBTCProvider[];
         "installedProviders": WebBTCProvider[];
+        "persistSelection": boolean;
     }
 }
 declare global {
@@ -29,6 +30,7 @@ declare namespace LocalJSX {
         "callback"?: Function;
         "defaultProviders"?: WebBTCProvider[];
         "installedProviders"?: WebBTCProvider[];
+        "persistSelection"?: boolean;
     }
     interface IntrinsicElements {
         "connect-modal": ConnectModal;

--- a/packages/connect-ui/src/components/modal/modal.tsx
+++ b/packages/connect-ui/src/components/modal/modal.tsx
@@ -14,12 +14,14 @@ export class Modal {
   @Prop() defaultProviders: WebBTCProvider[];
   @Prop() installedProviders: WebBTCProvider[];
 
+  @Prop() persistSelection: boolean;
+
   @Prop() callback: Function;
 
   @Element() modalEl: HTMLConnectModalElement;
 
   handleSelectProvider(providerId: string) {
-    setSelectedProviderId(providerId);
+    if (this.persistSelection) setSelectedProviderId(providerId);
     this.modalEl.remove();
     this.callback();
   }

--- a/packages/connect-ui/src/components/modal/readme.md
+++ b/packages/connect-ui/src/components/modal/readme.md
@@ -7,11 +7,12 @@
 
 ## Properties
 
-| Property             | Attribute | Description | Type               | Default     |
-| -------------------- | --------- | ----------- | ------------------ | ----------- |
-| `callback`           | --        |             | `Function`         | `undefined` |
-| `defaultProviders`   | --        |             | `WebBTCProvider[]` | `undefined` |
-| `installedProviders` | --        |             | `WebBTCProvider[]` | `undefined` |
+| Property             | Attribute           | Description | Type               | Default     |
+| -------------------- | ------------------- | ----------- | ------------------ | ----------- |
+| `callback`           | --                  |             | `Function`         | `undefined` |
+| `defaultProviders`   | --                  |             | `WebBTCProvider[]` | `undefined` |
+| `installedProviders` | --                  |             | `WebBTCProvider[]` | `undefined` |
+| `persistSelection`   | `persist-selection` |             | `boolean`          | `undefined` |
 
 
 ----------------------------------------------

--- a/packages/connect/src/ui.ts
+++ b/packages/connect/src/ui.ts
@@ -45,7 +45,11 @@ export type ActionOptions = (
   defaultProviders?: WebBTCProvider[];
 };
 
-function wrapConnectCall<O extends ActionOptions>(action: (o: O, p?: StacksProvider) => any) {
+/** Helper higher-order function for creating connect methods that allow for wallet selection */
+function wrapConnectCall<O extends ActionOptions>(
+  action: (o: O, p?: StacksProvider) => any,
+  persistSelection = true
+) {
   return function wrapped(o: O, p?: StacksProvider) {
     if (p) return action(o, p); // if a provider is passed, use it
 
@@ -62,6 +66,7 @@ function wrapConnectCall<O extends ActionOptions>(action: (o: O, p?: StacksProvi
     const element = document.createElement('connect-modal');
     element.defaultProviders = defaultProviders;
     element.installedProviders = installedProviders;
+    element.persistSelection = persistSelection;
     element.callback = () => action(o);
 
     document.body.appendChild(element);
@@ -77,7 +82,7 @@ function wrapConnectCall<O extends ActionOptions>(action: (o: O, p?: StacksProvi
 }
 
 /** A wrapper for selecting a wallet (if none is selected) and then calling the {@link authenticate} action. */
-export const showConnect = wrapConnectCall(authenticate);
+export const showConnect = wrapConnectCall(authenticate, false);
 
 /** A wrapper for selecting a wallet (if none is selected) and then calling the {@link openSTXTransfer} action. */
 export const showSTXTransfer = wrapConnectCall(openSTXTransfer);


### PR DESCRIPTION
> This PR was published to npm with the alpha versions:
> - connect `npm install @stacks/connect@7.4.3-alpha.f84e183.0 --save-exact`
> - connect-react `npm install @stacks/connect-react@22.2.3-alpha.f84e183.0 --save-exact`
> - connect-ui `npm install @stacks/connect-ui@6.1.4-alpha.f84e183.0 --save-exact`<!-- Sticky Header Marker -->

@beguene I added a small tweak, that will not persist the selection for the `authenticate` method, but only for the newly added methods. This way the recent Connect commit is not a "breaking change".

- Introduces the `persistSelection` boolean, to let users have the selection dialog always appear