### PR TITLE
fix: update scroll and callbacks

### DIFF
--- a/.changeset/rare-spiders-pull.md
+++ b/.changeset/rare-spiders-pull.md
@@ -1,0 +1,6 @@
+---
+'@stacks/connect-ui': minor
+'@stacks/connect': minor
+---
+
+Disables scrolling of the site when the modal is open

--- a/.changeset/sixty-schools-remember.md
+++ b/.changeset/sixty-schools-remember.md
@@ -1,0 +1,6 @@
+---
+'@stacks/connect-ui': minor
+'@stacks/connect': minor
+---
+
+Adds cancelCallback to modal, which is triggers onCancel

--- a/packages/connect-ui/src/components.d.ts
+++ b/packages/connect-ui/src/components.d.ts
@@ -9,6 +9,7 @@ import { WebBTCProvider } from "./providers";
 export namespace Components {
     interface ConnectModal {
         "callback": Function;
+        "cancelCallback": Function;
         "defaultProviders": WebBTCProvider[];
         "installedProviders": WebBTCProvider[];
         "persistSelection": boolean;
@@ -28,6 +29,7 @@ declare global {
 declare namespace LocalJSX {
     interface ConnectModal {
         "callback"?: Function;
+        "cancelCallback"?: Function;
         "defaultProviders"?: WebBTCProvider[];
         "installedProviders"?: WebBTCProvider[];
         "persistSelection"?: boolean;

--- a/packages/connect-ui/src/components/modal/modal.tsx
+++ b/packages/connect-ui/src/components/modal/modal.tsx
@@ -17,18 +17,17 @@ export class Modal {
   @Prop() persistSelection: boolean;
 
   @Prop() callback: Function;
+  @Prop() cancelCallback: Function;
 
   @Element() modalEl: HTMLConnectModalElement;
 
   handleSelectProvider(providerId: string) {
     if (this.persistSelection) setSelectedProviderId(providerId);
-    this.modalEl.remove();
     this.callback(getProviderFromId(providerId));
   }
 
   handleCloseModal() {
-    this.modalEl.remove();
-    // todo: throw Error that website can catch and handle (e.g. ConnectCancelError)
+    this.cancelCallback();
   }
 
   // todo: nice to have:
@@ -80,8 +79,9 @@ export class Modal {
     const hasMore = notInstalledProviders.length > 0;
 
     return (
-      <div class="modal-container animate-in fade-in fixed inset-0 z-[8999] box-border flex h-full w-full items-end overflow-y-scroll bg-[#00000040] md:items-center md:justify-center">
-        <div class="modal-body animate-in md:zoom-in-50 slide-in-from-bottom md:slide-in-from-bottom-0 box-border flex max-h-[calc(100%-24px)] w-full max-w-full cursor-default flex-col overflow-y-scroll rounded-2xl rounded-b-none bg-white p-6 text-sm leading-snug shadow-[0_4px_5px_0_#00000005,0_16px_40px_0_#00000014] md:max-h-[calc(100%-48px)] md:w-[400px] md:rounded-b-2xl">
+      <div class="modal-container animate-in fade-in fixed inset-0 z-[8999] box-border flex h-full w-full items-end bg-[#00000040] md:items-center md:justify-center">
+        <div class="fixed inset-0 z-[8999]" onClick={() => this.handleCloseModal()} />
+        <div class="modal-body animate-in md:zoom-in-50 slide-in-from-bottom md:slide-in-from-bottom-0 z-[9000] box-border flex max-h-[calc(100%-24px)] w-full max-w-full cursor-default flex-col overflow-y-scroll rounded-2xl rounded-b-none bg-white p-6 text-sm leading-snug shadow-[0_4px_5px_0_#00000005,0_16px_40px_0_#00000014] md:max-h-[calc(100%-48px)] md:w-[400px] md:rounded-b-2xl">
           {/* INTRO */}
           <div class="flex flex-col space-y-[10px]">
             <div class="flex items-center">
@@ -105,7 +105,7 @@ export class Modal {
           </div>
 
           {!mobile && !browser && (
-            <div class="mx-auto mt-4 rounded-xl bg-gray-200 px-3 py-1.5 text-sm font-medium text-gray-500 transition-colors hover:bg-gray-300">
+            <div class="mx-auto mt-4 rounded-xl bg-gray-200 px-3 py-1.5 text-sm font-medium text-gray-500">
               Unfortunately, your browser isn't supported
             </div>
           )}

--- a/packages/connect-ui/src/components/modal/readme.md
+++ b/packages/connect-ui/src/components/modal/readme.md
@@ -10,6 +10,7 @@
 | Property             | Attribute           | Description | Type               | Default     |
 | -------------------- | ------------------- | ----------- | ------------------ | ----------- |
 | `callback`           | --                  |             | `Function`         | `undefined` |
+| `cancelCallback`     | --                  |             | `Function`         | `undefined` |
 | `defaultProviders`   | --                  |             | `WebBTCProvider[]` | `undefined` |
 | `installedProviders` | --                  |             | `WebBTCProvider[]` | `undefined` |
 | `persistSelection`   | `persist-selection` |             | `boolean`          | `undefined` |

--- a/packages/connect/src/stories/ConnectPage.tsx
+++ b/packages/connect/src/stories/ConnectPage.tsx
@@ -16,6 +16,12 @@ export const ConnectPage = ({ children }: { children?: any }) => {
       <button onClick={connect}>Connect Wallet</button>
       <button onClick={() => clearSelectedProviderId()}>Disconnect</button>
       {children}
+      <div
+        style={{
+          backgroundColor: '#f0f0f0',
+          height: '2000px', // very high, to test scrolling
+        }}
+      />
     </div>
   );
 };

--- a/packages/connect/src/ui.ts
+++ b/packages/connect/src/ui.ts
@@ -67,8 +67,23 @@ function wrapConnectCall<O extends ActionOptions>(
     element.defaultProviders = defaultProviders;
     element.installedProviders = installedProviders;
     element.persistSelection = persistSelection;
-    element.callback = (selectedProvider: StacksProvider | undefined) =>
+
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const closeModal = () => {
+      element.remove();
+      document.body.style.overflow = originalOverflow;
+    };
+
+    element.callback = (selectedProvider: StacksProvider | undefined) => {
+      closeModal();
       action(options, selectedProvider);
+    };
+    element.cancelCallback = () => {
+      closeModal();
+      options.onCancel?.();
+    };
 
     document.body.appendChild(element);
 


### PR DESCRIPTION
> This PR was published to npm with the alpha versions:
> - connect `npm install @stacks/connect@7.6.1-alpha.8ffdb23.0 --save-exact`
> - connect-react `npm install @stacks/connect-react@22.4.1-alpha.8ffdb23.0 --save-exact`
> - connect-ui `npm install @stacks/connect-ui@6.3.1-alpha.8ffdb23.0 --save-exact`<!-- Sticky Header Marker -->

- update scrolling behavior to not let underneath site scroll when modal is open
- adds missing onCancel trigger

thanks to @fess-v 🙏