### PR TITLE
fix: pass url for new networks

### DIFF
--- a/.changeset/rich-radios-agree.md
+++ b/.changeset/rich-radios-agree.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Fix bug where url wasn't passed to network instance

--- a/packages/connect/src/utils.ts
+++ b/packages/connect/src/utils.ts
@@ -21,9 +21,10 @@ export function legacyNetworkFromConnectNetwork(network?: ConnectNetwork): Legac
   if (!network) return new LegacyStacksTestnet();
   if (typeof network === 'string') return LegacyStacksNetwork.fromName(network);
   if ('version' in network) return network; // legacy type
+
   if ('url' in network) return new LegacyStacksMainnet({ url: network.url }); // experimental
 
   return network.transactionVersion === (TransactionVersion.Mainnet as number)
-    ? new LegacyStacksMainnet()
-    : new LegacyStacksTestnet();
+    ? new LegacyStacksMainnet({ url: network.client.baseUrl })
+    : new LegacyStacksTestnet({ url: network.client.baseUrl });
 }


### PR DESCRIPTION
> This PR was published to npm with the alpha versions:
> - connect `npm install @stacks/connect@7.8.1-alpha.a1d9796.0 --save-exact`
> - connect-react `npm install @stacks/connect-react@22.5.1-alpha.a1d9796.0 --save-exact`
> - connect-ui `npm install @stacks/connect-ui@6.5.1-alpha.a1d9796.0 --save-exact`<!-- Sticky Header Marker -->

- fixes issue reported by @ECBSJ (url wasn't passed on)