### PR TITLE
Fix: undefined window on asigna initializer

### DIFF
--- a/.changeset/cuddly-colts-beg.md
+++ b/.changeset/cuddly-colts-beg.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Avoid Asigna initialization when the window object is not defined

--- a/packages/connect/src/asigna.ts
+++ b/packages/connect/src/asigna.ts
@@ -26,6 +26,8 @@ const generateAsignaMessage = (payload: string, key: string) => {
 };
 
 export const initializeAsignaProvider = () => {
+  if (typeof window === 'undefined') return;
+
   const isAsignaIframe = !!window.top && document.referrer.endsWith('.asigna.io/');
   if (isAsignaIframe) {
     window['AsignaProvider'] = AsignaIframeProvider;


### PR DESCRIPTION
## Description

Describe the changes that where made in this pull request. When possible start with a user story - short, simple descriptions of a feature told from the perspective of the person who desires the new capability. Be sure to also include the following information:

1. Motivation for change
- Server-side Next.js builds a broken because any import from `@stacks/connect` package will call `initializeAsignaProvider` which tries to access the `window` object without checking if it's defined.
3. What was changed
- Added a condition to check if `window` exists before trying to initialize Asigna Provider
- Added changeset file
5. How does this impact application developers
- Fixes the broken builds
7. Link to relevant issues and documentation
- Closes https://github.com/hirosystems/connect/issues/402

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?

No.

## Are documentation updates required?

No.

@janniks
