### PR TITLE
fix: patch raw types overrides

### DIFF
--- a/.changeset/five-seas-give.md
+++ b/.changeset/five-seas-give.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Add missing `sendTransfer` method

--- a/.changeset/soft-ravens-yawn.md
+++ b/.changeset/soft-ravens-yawn.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Fix raw methods for `requestRaw` function

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -27,7 +27,7 @@ yarn add @stacks/connect
 import { request } from '@stacks/connect';
 
 // CONNECT
-const response = await request('getAddresses');
+const response = await request({ forceWalletSelect: true }, 'getAddresses');
 ```
 
 ### Available methods <!-- omit in toc -->

--- a/packages/connect/src/stories/ConnectPage.tsx
+++ b/packages/connect/src/stories/ConnectPage.tsx
@@ -390,7 +390,7 @@ const LegacySignStructuredMessageForm = () => {
       // Create a structured message using Clarity values
       const clarityMessage = Cl.parse(message);
       const clarityDomain = Cl.tuple({
-        domain: Cl.stringAscii(domain),
+        name: Cl.stringAscii(domain),
         version: Cl.stringAscii('1.0.0'),
         'chain-id': Cl.uint(1),
       });

--- a/packages/connect/src/stories/ConnectPage.tsx
+++ b/packages/connect/src/stories/ConnectPage.tsx
@@ -497,6 +497,63 @@ const GetAddressesForm = () => {
   );
 };
 
+// Send Transfer Form Component
+const SendTransferForm = () => {
+  type SendTransferFormData = {
+    address: string;
+    amount: string;
+  };
+  const methods = useForm<SendTransferFormData>();
+  const { register, handleSubmit } = methods;
+  const refresh = useReducer(x => x + 1, 0)[1];
+  const [response, setResponse] = useState<any>(null);
+
+  const onSubmit = handleSubmit(({ address, amount }, e) => {
+    e.preventDefault();
+    request('sendTransfer', {
+      recipients: [{ address, amount }],
+    })
+      .then(d => {
+        setResponse(d);
+        refresh();
+      })
+      .catch(e => {
+        setResponse({ error: e?.toString() });
+        refresh();
+        throw e;
+      });
+  });
+
+  return (
+    <FormProvider {...methods}>
+      <section>
+        <h3>sendTransfer</h3>
+        <form onSubmit={e => void onSubmit(e)}>
+          <div>
+            <label htmlFor="recipient">Recipient</label>
+            <input
+              id="address"
+              {...register('address', { required: true })}
+              defaultValue="bc1qul02aptw6x3t0ltn0mvdrlask3r6uqyln3pfeg"
+            />
+          </div>
+          <div>
+            <label htmlFor="amount">Amount (sats)</label>
+            <input id="amount" {...register('amount', { required: true })} defaultValue="1000" />
+          </div>
+          <button type="submit">Send Transfer</button>
+        </form>
+        {response && (
+          <div data-response>
+            <h3>Response</h3>
+            <pre>{JSON.stringify(response, null, 2)}</pre>
+          </div>
+        )}
+      </section>
+    </FormProvider>
+  );
+};
+
 // STX Get Addresses Form Component
 const STXGetAddressesForm = () => {
   type STXGetAddressesFormData = {
@@ -1030,6 +1087,7 @@ export const ConnectPage = ({ children }: { children?: any }) => {
 
             {/* MODERN REQUEST METHODS GO HERE */}
             <GetAddressesForm />
+            <SendTransferForm />
             <STXGetAddressesForm />
             <STXGetAccountsForm />
             <STXTransferForm />

--- a/packages/connect/src/types/provider.ts
+++ b/packages/connect/src/types/provider.ts
@@ -1,8 +1,8 @@
-import { JsonRpcResponse, MethodParams, Methods } from '../methods';
+import { JsonRpcResponse, MethodParamsRaw, MethodsRaw } from '../methods';
 
 export interface StacksProvider {
-  request<M extends keyof Methods>(
+  request<M extends keyof MethodsRaw>(
     method: M,
-    params?: MethodParams<M>
+    params?: MethodParamsRaw<M>
   ): Promise<JsonRpcResponse<M>>;
 }


### PR DESCRIPTION
> This PR was published to npm with versions:
> - connect `npm install @stacks/connect@8.0.1-alpha.f0449df.0 --save-exact`
> - connect-react `npm install @stacks/connect-react@23.0.1-alpha.f0449df.0 --save-exact`
> - connect-ui `npm install @stacks/connect-ui@7.0.1-alpha.f0449df.0 --save-exact`<!-- Sticky Header Marker -->

- fixes some types (raw method shouldn't be able to use all types)
- adds missing `sendTransfer` method
- fixes some overrides in the missing `sendTransfer` method