### PR TITLE
fix: update override

### DIFF
--- a/.changeset/curly-dryers-share.md
+++ b/.changeset/curly-dryers-share.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Fix case where Xverse-like wallet isn't included in overrides

--- a/packages/connect/src/request.ts
+++ b/packages/connect/src/request.ts
@@ -217,6 +217,10 @@ export function requestRawLegacy<M extends keyof Methods, O, R>(
 // onFinish?: ProfileUpdateFinished;
 // onCancel?: ProfileUpdateCanceled;
 
+function isXverseLike(provider: StacksProvider): boolean {
+  return isXverse(provider) || isFordefi(provider);
+}
+
 function isXverse(provider: StacksProvider): boolean {
   return (
     // Best effort detection for Xverse
@@ -254,7 +258,7 @@ function getMethodOverrides<M extends keyof Methods>(
 
   // Xverse-ish wallets
   if (
-    (isXverse(provider) || isFordefi(provider)) &&
+    isXverseLike(provider) &&
     // Permission granting method
     ['getAddresses', 'stx_getAddresses'].includes(method)
   ) {
@@ -262,7 +266,7 @@ function getMethodOverrides<M extends keyof Methods>(
   }
 
   // Xverse-ish `sendTransfer`
-  if (isXverse(provider) && method === 'sendTransfer') {
+  if (isXverseLike(provider) && method === 'sendTransfer') {
     const paramsXverse = {
       ...params,
       recipients: (params as SendTransferParams).recipients.map(r => ({


### PR DESCRIPTION
> This PR was published to npm with versions:
> - connect `npm install @stacks/connect@8.0.2-alpha.b3d5f88.0 --save-exact`
> - connect-react `npm install @stacks/connect-react@23.0.2-alpha.b3d5f88.0 --save-exact`
> - connect-ui `npm install @stacks/connect-ui@7.0.1-alpha.b3d5f88.0 --save-exact`<!-- Sticky Header Marker -->

- Fix missing override case where Fordefi was missing (as an Xverse-like wallet), so added a helper so it's more clear for the future.