### PR TITLE
fix: add missing param

### DIFF
--- a/.changeset/cuddly-buttons-beam.md
+++ b/.changeset/cuddly-buttons-beam.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Add missing broadcast argument for signPsbt

--- a/packages/connect/src/methods.ts
+++ b/packages/connect/src/methods.ts
@@ -186,6 +186,7 @@ export interface SignInputsByAddress {
 export interface SignPsbtParams {
   psbt: string;
   signInputs?: number[] | SignInputsByAddress[];
+  broadcast?: boolean;
 
   /** @experimental Might need a rename, when wallets adopt SIPs/WBIPs. */
   allowedSighash?: Sighash[];


### PR DESCRIPTION
> This PR was published to npm with versions:
> - connect `npm install @stacks/connect@8.0.2-alpha.b039684.0 --save-exact`
> - connect-react `npm install @stacks/connect-react@23.0.2-alpha.b039684.0 --save-exact`
> - connect-ui `npm install @stacks/connect-ui@7.0.1-alpha.b039684.0 --save-exact`<!-- Sticky Header Marker -->

_tiny followup:_
- add missing broadcast param