### PR TITLE
fix: move persist to only success case

### DIFF
--- a/.changeset/happy-ads-compare.md
+++ b/.changeset/happy-ads-compare.md
@@ -1,0 +1,6 @@
+---
+'@stacks/connect-ui': major
+'@stacks/connect': patch
+---
+
+Only persist wallet selection on success case

--- a/packages/connect-ui/src/components.d.ts
+++ b/packages/connect-ui/src/components.d.ts
@@ -12,7 +12,6 @@ export namespace Components {
         "cancelCallback": Function;
         "defaultProviders": WbipProvider[];
         "installedProviders": WbipProvider[];
-        "persistWalletSelect": boolean;
     }
 }
 declare global {
@@ -32,7 +31,6 @@ declare namespace LocalJSX {
         "cancelCallback"?: Function;
         "defaultProviders"?: WbipProvider[];
         "installedProviders"?: WbipProvider[];
-        "persistWalletSelect"?: boolean;
     }
     interface IntrinsicElements {
         "connect-modal": ConnectModal;

--- a/packages/connect-ui/src/components/modal/modal.tsx
+++ b/packages/connect-ui/src/components/modal/modal.tsx
@@ -1,6 +1,5 @@
 import { Component, Element, Prop, h } from '@stencil/core';
-import { WbipProvider, getProviderFromId } from '../../providers';
-import { setSelectedProviderId } from '../../session';
+import { WbipProvider } from '../../providers';
 import CloseIcon from './assets/close-icon.svg';
 import { getBrowser, getPlatform } from './utils';
 
@@ -14,16 +13,13 @@ export class Modal {
   @Prop() defaultProviders: WbipProvider[];
   @Prop() installedProviders: WbipProvider[];
 
-  @Prop() persistWalletSelect: boolean;
-
   @Prop() callback: Function;
   @Prop() cancelCallback: Function;
 
   @Element() modalEl: HTMLConnectModalElement;
 
   handleSelectProvider(providerId: string) {
-    if (this.persistWalletSelect) setSelectedProviderId(providerId);
-    this.callback(getProviderFromId(providerId));
+    this.callback(providerId);
   }
 
   handleCloseModal() {

--- a/packages/connect-ui/src/components/modal/readme.md
+++ b/packages/connect-ui/src/components/modal/readme.md
@@ -7,13 +7,12 @@
 
 ## Properties
 
-| Property              | Attribute               | Description | Type             | Default     |
-| --------------------- | ----------------------- | ----------- | ---------------- | ----------- |
-| `callback`            | --                      |             | `Function`       | `undefined` |
-| `cancelCallback`      | --                      |             | `Function`       | `undefined` |
-| `defaultProviders`    | --                      |             | `WbipProvider[]` | `undefined` |
-| `installedProviders`  | --                      |             | `WbipProvider[]` | `undefined` |
-| `persistWalletSelect` | `persist-wallet-select` |             | `boolean`        | `undefined` |
+| Property             | Attribute | Description | Type             | Default     |
+| -------------------- | --------- | ----------- | ---------------- | ----------- |
+| `callback`           | --        |             | `Function`       | `undefined` |
+| `cancelCallback`     | --        |             | `Function`       | `undefined` |
+| `defaultProviders`   | --        |             | `WbipProvider[]` | `undefined` |
+| `installedProviders` | --        |             | `WbipProvider[]` | `undefined` |
 
 
 ----------------------------------------------


### PR DESCRIPTION
> This PR was published to npm with versions:
> - connect `npm install @stacks/connect@8.0.3-alpha.e842731.0 --save-exact`
> - connect-react `npm install @stacks/connect-react@23.0.3-alpha.e842731.0 --save-exact`
> - connect-ui `npm install @stacks/connect-ui@7.0.1-alpha.e842731.0 --save-exact`<!-- Sticky Header Marker -->

- fixes https://github.com/hirosystems/connect/issues/419