### PR TITLE
fix: strip network

### DIFF
--- a/.changeset/long-jars-pay.md
+++ b/.changeset/long-jars-pay.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Strip `network` from sendTransfer method on Xverse-like wallets

--- a/packages/connect/src/methods.ts
+++ b/packages/connect/src/methods.ts
@@ -117,6 +117,7 @@ export interface SendTransferParams {
     address: string;
     amount: Integer;
   }[];
+  network?: NetworkString;
 }
 
 export interface GetAccountsParams {

--- a/packages/connect/src/request.ts
+++ b/packages/connect/src/request.ts
@@ -355,6 +355,7 @@ function getMethodOverrides<M extends keyof Methods>(
         ...r,
         amount: Number(r.amount), // Xverse expects amount as number
       })),
+      network: undefined, // strip network until Xverse adds it as optional
     };
     return { method, params: paramsXverse };
   }


### PR DESCRIPTION
> This PR was published to npm with versions:
> - connect `npm install @stacks/connect@8.1.2-alpha.0edb52a.0 --save-exact`
> - connect-react `npm install @stacks/connect-react@23.0.5-alpha.0edb52a.0 --save-exact`
> - connect-ui `npm install @stacks/connect-ui@8.0.1-alpha.0edb52a.0 --save-exact`<!-- Sticky Header Marker -->

- strip network from xverse sendTransfer calls