### PR TITLE
fix: update signpsbt overrides

### DIFF
--- a/.changeset/clever-donuts-cover.md
+++ b/.changeset/clever-donuts-cover.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Fix signPsbt overrides for Xverse and Leather

--- a/packages/connect/src/methods.ts
+++ b/packages/connect/src/methods.ts
@@ -177,7 +177,7 @@ export type Sighash = 'ALL' | 'NONE' | 'SINGLE' | 'ANYONECANPAY';
 
 export interface SignInputsByAddress {
   index: number;
-  address?: string;
+  address: string; // todo: make optional again when Xverse adopts it
   publicKey?: string;
 
   /** @experimental Might need a rename, when wallets adopt SIPs/WBIPs. */
@@ -188,6 +188,7 @@ export interface SignPsbtParams {
   psbt: string;
   signInputs?: number[] | SignInputsByAddress[];
   broadcast?: boolean;
+  network?: NetworkString;
 
   /** @experimental Might need a rename, when wallets adopt SIPs/WBIPs. */
   allowedSighash?: Sighash[];


### PR DESCRIPTION
> This PR was published to npm with versions:
> - connect `npm install @stacks/connect@8.1.2-alpha.5cdeea2.0 --save-exact`
> - connect-react `npm install @stacks/connect-react@23.0.5-alpha.5cdeea2.0 --save-exact`
> - connect-ui `npm install @stacks/connect-ui@8.0.1-alpha.5cdeea2.0 --save-exact`<!-- Sticky Header Marker -->

- update overrides for xverse and leather