### PR TITLE
fix: add missing export

### DIFF
--- a/.changeset/smooth-humans-teach.md
+++ b/.changeset/smooth-humans-teach.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Add missing export

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -34,7 +34,7 @@ export {
   openSTXTransfer,
   openSignTransaction,
 } from './transactions';
-export { request, requestRaw } from './request';
+export { connect, request, requestRaw } from './request';
 export {
   getLocalStorage,
   clearLocalStorage,


### PR DESCRIPTION
> This PR was published to npm with versions:
> - connect `npm install @stacks/connect@8.1.3-alpha.4180c63.0 --save-exact`
> - connect-react `npm install @stacks/connect-react@23.0.6-alpha.4180c63.0 --save-exact`
> - connect-ui `npm install @stacks/connect-ui@8.0.1-alpha.4180c63.0 --save-exact`<!-- Sticky Header Marker -->

- add missing export statement
