### PR TITLE
fix: add params to connect method

### DIFF
--- a/.changeset/gentle-colts-dress.md
+++ b/.changeset/gentle-colts-dress.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Add authResponsePayload to authentication result for more backwards compatibility

--- a/.changeset/good-cheetahs-sip.md
+++ b/.changeset/good-cheetahs-sip.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Allow `connect()` to take any `getAddresses` params as options

--- a/.changeset/great-pugs-cheer.md
+++ b/.changeset/great-pugs-cheer.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Fix address storage issue for Xverse-like wallets

--- a/.changeset/little-toys-happen.md
+++ b/.changeset/little-toys-happen.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Remove potentially unwanted private information from being stored in local storage

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Follow the **Getting Started** section of the [`@stacks/connect` README](https:/
 This repository includes three packages:
 
 - [`@stacks/connect`](./packages/connect): The one-stop-shop tool for letting web-apps interact with Stacks web wallets.
-- [`@stacks/connect-react`](./packages/connect-react): A wrapper library for making `@stacks/connect` use in React even easier
 - [`@stacks/connect-ui`](./packages/connect-ui): A web-component UI for displaying an intro modal in Stacks web-apps during authentication _(used in the background by `@stacks/connect`)_.
+- ~~[`@stacks/connect-react`](./packages/connect-react): A wrapper library for making `@stacks/connect` use in React even easier~~
 
 ## 🛠️ Wallet Implementation Guide
 

--- a/packages/connect-react/README.md
+++ b/packages/connect-react/README.md
@@ -1,5 +1,3 @@
-# `@stacks/connect`
+# `@stacks/connect-react`
 
-A library for building excellent user experiences with [Blockstack](https://blockstack.org/).
-
-:blue_book: [View documentation](https://docs.blockstack.org/develop/connect/overview.html)
+A new `@stacks/react` experience is coming soon 🤫

--- a/packages/connect/src/auth.ts
+++ b/packages/connect/src/auth.ts
@@ -74,7 +74,7 @@ export const authenticate = async (authOptions: AuthOptions, provider?: StacksPr
 
     userSession.store.setSessionData(sessionData);
 
-    onFinish?.({ userSession });
+    onFinish?.({ userSession, authResponsePayload: sessionData.userData });
   } catch (error) {
     console.error('[Connect] Error during auth request', error);
     onCancel?.(error);

--- a/packages/connect/src/methods.ts
+++ b/packages/connect/src/methods.ts
@@ -110,6 +110,8 @@ export interface SignStructuredMessageParams {
 
 export interface GetAddressesParams {
   network?: NetworkString;
+  // When updating this interface, make sure to update the `connect` function
+  // in `request.ts`, to pass all available params to the wrapped method.
 }
 
 export interface SendTransferParams {

--- a/packages/connect/src/request.ts
+++ b/packages/connect/src/request.ts
@@ -256,7 +256,7 @@ function requestArgs<M extends keyof Methods>(
  * Alias for `request` to `getAddresses` with `forceWalletSelect: true`.
  */
 export function connect(options?: ConnectRequestOptions & MethodParams<'getAddresses'>) {
-  const params = 'network' in options ? { network: options.network } : undefined;
+  const params = options && 'network' in options ? { network: options.network } : undefined;
   return request({ ...options, forceWalletSelect: true }, 'getAddresses', params);
 }
 

--- a/packages/connect/src/request.ts
+++ b/packages/connect/src/request.ts
@@ -251,8 +251,9 @@ function requestArgs<M extends keyof Methods>(
  * Initiate a wallet connection and request addresses.
  * Alias for `request` to `getAddresses` with `forceWalletSelect: true`.
  */
-export function connect(options?: ConnectRequestOptions) {
-  return request({ ...options, forceWalletSelect: true }, 'getAddresses');
+export function connect(options?: ConnectRequestOptions & MethodParams<'getAddresses'>) {
+  const params = 'network' in options ? { network: options.network } : undefined;
+  return request({ ...options, forceWalletSelect: true }, 'getAddresses', params);
 }
 
 /**

--- a/packages/connect/src/storage.ts
+++ b/packages/connect/src/storage.ts
@@ -30,7 +30,12 @@ export const normalizeAddresses = (
   addresses: AddressEntry[]
 ): Omit<AddressEntry, 'publicKey'>[] => {
   const deduped = [...new Map(addresses.map(a => [a.address, a])).values()];
-  return deduped.map(({ publicKey, ...rest }) => rest);
+  return deduped.map(({ ...a }) => {
+    if ('publicKey' in a) delete a.publicKey;
+    if ('derivationPath' in a) delete a.derivationPath;
+    if ('tweakedPublicKey' in a) delete a.tweakedPublicKey;
+    return a;
+  });
 };
 
 /**

--- a/packages/connect/src/types/auth.ts
+++ b/packages/connect/src/types/auth.ts
@@ -2,21 +2,36 @@ import { UserSession } from '../auth';
 
 /** @deprecated */
 export interface AuthResponsePayload {
-  private_key: string;
-  username: string | null;
-  hubUrl: string;
-  associationToken: string;
-  blockstackAPIUrl: string | null;
-  core_token: string | null;
-  email: string | null;
-  exp: number;
-  iat: number;
-  iss: string;
-  jti: string;
-  version: string;
   profile: any;
-  profile_url: string;
-  public_keys: string[];
+
+  /** @deprecated Not set in the `request` flow anymore. */
+  private_key?: string;
+  /** @deprecated Not set in the `request` flow anymore. */
+  username?: string | null;
+  /** @deprecated Not set in the `request` flow anymore. */
+  hubUrl?: string;
+  /** @deprecated Not set in the `request` flow anymore. */
+  associationToken?: string;
+  /** @deprecated Not set in the `request` flow anymore. */
+  blockstackAPIUrl?: string | null;
+  /** @deprecated Not set in the `request` flow anymore. */
+  core_token?: string | null;
+  /** @deprecated Not set in the `request` flow anymore. */
+  email?: string | null;
+  /** @deprecated Not set in the `request` flow anymore. */
+  exp?: number;
+  /** @deprecated Not set in the `request` flow anymore. */
+  iat?: number;
+  /** @deprecated Not set in the `request` flow anymore. */
+  iss?: string;
+  /** @deprecated Not set in the `request` flow anymore. */
+  jti?: string;
+  /** @deprecated Not set in the `request` flow anymore. */
+  version?: string;
+  /** @deprecated Not set in the `request` flow anymore. */
+  profile_url?: string;
+  /** @deprecated Not set in the `request` flow anymore. */
+  public_keys?: string[];
 }
 
 /** @deprecated */


### PR DESCRIPTION
> This PR was published to npm with versions:
> - connect `npm install @stacks/connect@8.1.4-alpha.38fa12b.0 --save-exact`
> - connect-react `npm install @stacks/connect-react@23.0.7-alpha.38fa12b.0 --save-exact`
> - connect-ui `npm install @stacks/connect-ui@8.0.1-alpha.38fa12b.0 --save-exact`<!-- Sticky Header Marker -->

- add missing params to make `connect()` be able to do anything that `getAddresses` can
- fix storage issue where xverse addresses weren't stored correctly