### PR TITLE
fix: export types

### DIFF
--- a/.changeset/flat-lions-hide.md
+++ b/.changeset/flat-lions-hide.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Export method types

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -35,6 +35,13 @@ export {
   openSignTransaction,
 } from './transactions';
 export { connect, request, requestRaw } from './request';
+export type {
+  Methods,
+  MethodParams,
+  MethodResult,
+  MethodParamsRaw,
+  MethodResultRaw,
+} from './methods';
 export {
   getLocalStorage,
   clearLocalStorage,

--- a/packages/connect/src/stories/ConnectPage.tsx
+++ b/packages/connect/src/stories/ConnectPage.tsx
@@ -197,7 +197,7 @@ const LegacyContractCallForm = () => {
         });
       } catch (e) {
         console.error(e);
-        setResponse({ error: `Failed to parse arguments: ${e.message}` });
+        setResponse({ error: `Failed to parse arguments: ${e.message || e}` });
       }
     }
   );
@@ -767,7 +767,7 @@ const STXContractCallForm = () => {
         });
     } catch (e) {
       console.error(e);
-      setResponse({ error: `Failed to parse arguments: ${e.message}` });
+      setResponse({ error: `Failed to parse arguments: ${e.message || e}` });
     }
   });
 
@@ -1113,10 +1113,12 @@ export const ConnectPage = ({ children }: { children?: any }) => {
               <pre>{JSON.stringify(connectResponse, null, 2)}</pre>
             </div>
           )}
-          <div data-response>
-            <h3>LocalStorage Content</h3>
-            <pre>{JSON.stringify(localStorageData, null, 2)}</pre>
-          </div>
+          {localStorageData && (
+            <div data-response>
+              <h3>LocalStorage Content</h3>
+              <pre>{JSON.stringify(localStorageData, null, 2)}</pre>
+            </div>
+          )}
         </section>
 
         {(isSignedIn || isConnected()) && (


### PR DESCRIPTION
> This PR was published to npm with versions:
> - connect `npm install @stacks/connect@8.1.5-alpha.626c72f.0 --save-exact`
> - connect-react `npm install @stacks/connect-react@23.0.8-alpha.626c72f.0 --save-exact`
> - connect-ui `npm install @stacks/connect-ui@8.0.1-alpha.626c72f.0 --save-exact`<!-- Sticky Header Marker -->

- export missing types