### PR TITLE
fix: wallet overrides

### DIFF
--- a/.changeset/stupid-deers-push.md
+++ b/.changeset/stupid-deers-push.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Add wallet result overrides for inconsistent wallet results


### PR DESCRIPTION
> This PR was published to npm with versions:
> - connect `npm install @stacks/connect@8.1.5-alpha.1fc741b.0 --save-exact`
> - connect-react `npm install @stacks/connect-react@23.0.8-alpha.1fc741b.0 --save-exact`
> - connect-ui `npm install @stacks/connect-ui@8.0.1-alpha.1fc741b.0 --save-exact`<!-- Sticky Header Marker -->

- add result overrides as well (some wallets have buggy results, or different standards) connect can balance them out in practice