### PR TITLE
fix: readme updates and fixes

### DIFF
--- a/.changeset/serious-planets-laugh.md
+++ b/.changeset/serious-planets-laugh.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Add `approvedProviderIds` options to filter allowed wallets

--- a/.changeset/twelve-eels-listen.md
+++ b/.changeset/twelve-eels-listen.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Export error types

--- a/README.md
+++ b/README.md
@@ -2,26 +2,15 @@
   <img src="/.github/img/banner.svg" alt="Stacks Connect">
 </div>
 
-Connect is a JavaScript library for building web applications connected to [Stacks](https://stacks.co).
+## ⚡️ Building a Stacks-enabled web app?
 
-<div align="center">
-  <code><a href="./packages/connect">@stacks/connect</a></code> •
-  <code><a href="./packages/connect-react">@stacks/connect-react</a></code> •
-  <code><a href="./packages/connect-ui">@stacks/connect-ui</a></code>
-</div>
-
-> See methods and migration notes in the [`@stacks/connect` documentation](./packages/connect).
+Head over to the [`@stacks/connect` README](https://github.com/hirosystems/connect/tree/main/packages/connect).
 
 ---
 
-## ⚡️ Installation
+## Development Notes
 
-Use your favorite package manager to install `@stacks/connect` in your project.
-Follow the **Getting Started** section of the [`@stacks/connect` README](https://github.com/hirosystems/connect/tree/main/packages/connect).
-
-> Or use one of our starter-templates to bootstrap a fresh project already including connect using the [command-line](https://github.com/hirosystems/stacks.js-starters) locally via `npm create stacks`
-
-## 📦 Packages
+### Packages
 
 This repository includes three packages:
 
@@ -29,7 +18,7 @@ This repository includes three packages:
 - [`@stacks/connect-ui`](./packages/connect-ui): A web-component UI for displaying an intro modal in Stacks web-apps during authentication _(used in the background by `@stacks/connect`)_.
 - ~~[`@stacks/connect-react`](./packages/connect-react): A wrapper library for making `@stacks/connect` use in React even easier~~
 
-## 🛠️ Wallet Implementation Guide
+### Wallet Implementation Guide
 
 Wallets implement a "Provider" interface.
 The latest spec uses a simple JS Object exposing a `.request(method: string, params?: object)` method.
@@ -86,7 +75,7 @@ window.wbip_providers.push({
 });
 ```
 
-### JSON RPC 2.0
+#### JSON RPC 2.0
 
 Wallets may add their own unstandardized methods.
 However, the minimum recommended methods are:

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -399,10 +399,14 @@ import { request } from '@stacks/connect';
 const response = await request(
   {
     provider?: StacksProvider;        // Custom provider to use for the request
-    defaultProviders?: WbipProvider[]; // Default wallets to display in modal
+
     forceWalletSelect?: boolean;      // Force user to select a wallet (default: false)
     persistWalletSelect?: boolean;     // Persist selected wallet (default: true)
     enableOverrides?: boolean;         // Enable provider compatibility (default: true)
+    enableLocalStorage?: boolean;      // Store address in local storage (default: true)
+
+    defaultProviders?: WbipProvider[]; // Default wallets to display in modal
+    approvedProviderIds?: string[];    // List of approved provider IDs to show in modal
   },
   'method',
   params
@@ -415,6 +419,20 @@ const response = await request('method', params);
 > The `enableOverrides` option enables automatic compatibility fixes for different wallet providers.
 > For example, it handles converting numeric types between string and number formats as needed by different wallets, and remaps certain method names to match wallet-specific implementations.
 > This ensures consistent behavior across different wallet providers without requiring manual adjustments.
+
+> The `approvedProviderIds` option allows you to filter which wallet providers are shown in the connect modal.
+> This is useful when you want to limit the available wallet options to specific providers.
+> For example, you might only want to support Leather wallet:
+>
+> ```ts
+> connect({ approvedProviderIds: ['LeatherProvider'] });
+> ```
+>
+> Or multiple specific wallets:
+>
+> ```ts
+> connect({ approvedProviderIds: ['LeatherProvider', 'xverse'] });
+> ```
 
 ### `requestRaw`
 

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -472,10 +472,13 @@ Here's a list of methods and events that are supported by popular wallets:
 | `stx_signStructuredMessage` | 🟡 <sub>Hex-encoded Clarity values only</sub>      | 🟡 <sub>Hex-encoded Clarity values only</sub>                                  |
 | `stx_updateProfile`         | 🔴                                                 | 🔴                                                                             |
 
-| Event               | Leather | Xverse |
-| ------------------- | ------- | ------ |
-| `stx_accountChange` | 🔴      | 🔴     |
-| `stx_networkChange` | 🔴      | 🔴     |
+| Event                 | Leather | Xverse |
+| --------------------- | ------- | ------ |
+| `accountChange`       | 🔴      | 🟢     |
+| `accountDisconnected` | 🔴      | 🟢     |
+| `networkChange`       | 🔴      | 🟢     |
+| `stx_accountChange`   | 🔴      | 🔴     |
+| `stx_networkChange`   | 🔴      | 🔴     |
 
 - 🔴 No support (yet)
 - 🟡 Partial support

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -451,23 +451,23 @@ const response = await requestRaw(provider, 'method', params);
 
 Here's a list of methods and events that are supported by popular wallets:
 
-| Method                      | Leather                                            | Xverse                                                  |
-| --------------------------- | -------------------------------------------------- | ------------------------------------------------------- |
-| `getAddresses`              | 🟡 <sub>No support for experimental purposes</sub> | 🟡 <sub>Use `wallet_connect` instead</sub>              |
-| `sendTransfer`              | 🟡 <sub>Expects `amount` as string</sub>           | 🟡 <sub>Expects `amount` as number</sub>                |
-| `signPsbt`                  | 🟡 <sub>Uses signing index array only</sub>        | 🟡 <sub>Uses `signInputs` record instead of array</sub> |
-| `stx_getAddresses`          | 🟢                                                 | 🔴                                                      |
-| `stx_getAccounts`           | 🔴                                                 | 🟢                                                      |
-| `stx_getNetworks`           | 🔴                                                 | 🔴                                                      |
-| `stx_transferStx`           | 🟢                                                 | 🟢                                                      |
-| `stx_transferSip10Ft`       | 🟢                                                 | 🔴                                                      |
-| `stx_transferSip9Nft`       | 🟢                                                 | 🔴                                                      |
-| `stx_callContract`          | 🟡 <sub>Hex-encoded Clarity values only</sub>      | 🟡 <sub>Hex-encoded Clarity values only</sub>           |
-| `stx_deployContract`        | 🟡 <sub>Hex-encoded Clarity values only</sub>      | 🟡 <sub>Hex-encoded Clarity values only</sub>           |
-| `stx_signTransaction`       | 🟡 <sub>Hex-encoded Clarity values only</sub>      | 🟡 <sub>Hex-encoded Clarity values only</sub>           |
-| `stx_signMessage`           | 🟡 <sub>Hex-encoded Clarity values only</sub>      | 🟡 <sub>Hex-encoded Clarity values only</sub>           |
-| `stx_signStructuredMessage` | 🟡 <sub>Hex-encoded Clarity values only</sub>      | 🟡 <sub>Hex-encoded Clarity values only</sub>           |
-| `stx_updateProfile`         | 🔴                                                 | 🔴                                                      |
+| Method                      | Leather                                            | Xverse-like                                                                    |
+| --------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `getAddresses`              | 🟡 <sub>No support for experimental purposes</sub> | 🟡 <sub>Use `wallet_connect` instead</sub>                                     |
+| `sendTransfer`              | 🟡 <sub>Expects `amount` as string</sub>           | 🟡 <sub>Expects `amount` as number</sub>                                       |
+| `signPsbt`                  | 🟡 <sub>Uses signing index array only</sub>        | 🟡 <sub>Uses `signInputs` record instead of array</sub>                        |
+| `stx_getAddresses`          | 🟢                                                 | 🔴                                                                             |
+| `stx_getAccounts`           | 🔴                                                 | 🟢                                                                             |
+| `stx_getNetworks`           | 🔴                                                 | 🔴                                                                             |
+| `stx_transferStx`           | 🟢                                                 | 🟢                                                                             |
+| `stx_transferSip10Ft`       | 🟢                                                 | 🔴                                                                             |
+| `stx_transferSip9Nft`       | 🟢                                                 | 🔴                                                                             |
+| `stx_callContract`          | 🟡 <sub>Hex-encoded Clarity values only</sub>      | 🟡 <sub>Hex-encoded Clarity values only, no support for `postConditions`</sub> |
+| `stx_deployContract`        | 🟡 <sub>Hex-encoded Clarity values only</sub>      | 🟡 <sub>Hex-encoded Clarity values only, no support for `postConditions`</sub> |
+| `stx_signTransaction`       | 🟡 <sub>Hex-encoded Clarity values only</sub>      | 🟡 <sub>Hex-encoded Clarity values only</sub>                                  |
+| `stx_signMessage`           | 🟡 <sub>Hex-encoded Clarity values only</sub>      | 🟡 <sub>Hex-encoded Clarity values only</sub>                                  |
+| `stx_signStructuredMessage` | 🟡 <sub>Hex-encoded Clarity values only</sub>      | 🟡 <sub>Hex-encoded Clarity values only</sub>                                  |
+| `stx_updateProfile`         | 🔴                                                 | 🔴                                                                             |
 
 | Event               | Leather | Xverse |
 | ------------------- | ------- | ------ |

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -57,16 +57,19 @@ npm install @stacks/connect@latest
 
 - `request` follows the pattern `request(method: string, params: object)`, see [Usage](#usage) for more details
 - `request` is an async function, so replace the `onFinish` and `onCancel` callbacks with `.then().catch()` or `try & await`
+- e.g., `showConnect()`, `authenticate()` → `connect()`
+- e.g., `useConnect().doContractCall({})` → `request("stx_callContract", {})`
+- e.g., `openContractDeploy()` → `request("stx_deployContract", {})`
 
-3. Switch from `showConnect` or`authenticate` to `connect()` methods
+1. Switch from `showConnect` or`authenticate` to `connect()` methods
 
    - `connect()` is an alias for `request({forceWalletSelect: true}, 'getAddresses')`
    - `connect()` by default caches the user's address in local storage
 
-4. Switch from `UserSession.isSignedIn()` to `isConnected()`
-5. Switch from `UserSession.signUserOut()` to `disconnect()`
-6. Remove code referencing deprecated methods (`AppConfig`, `UserSession`, etc.)
-7. Remove the `@stacks/connect-react` package.
+2. Switch from `UserSession.isSignedIn()` to `isConnected()`
+3. Switch from `UserSession.signUserOut()` to `disconnect()`
+4. Remove code referencing deprecated methods (`AppConfig`, `UserSession`, etc.)
+5. Remove the `@stacks/connect-react` package.
    - You may need to manually reload a component to see local storage updates.
    - No custom hooks are needed to use Stacks Connect anymore.
    - We are working on a new `@stacks/react` package that will make usage even easier in the future (e.g. tracking transaction status, reloading components when a connection is established, updating the page when the network changes, and more).

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -2,6 +2,7 @@ export * from './auth';
 export * from './providers';
 export * from './types';
 export * from './ui';
+export * from './errors';
 
 // Manual exports to avoid exporting internals (e.g. `LEGACY_XYZ`)
 export { getDefaultPsbtRequestOptions, makePsbtToken, openPsbtRequestPopup } from './bitcoin';

--- a/packages/connect/src/stories/Connect.stories.tsx
+++ b/packages/connect/src/stories/Connect.stories.tsx
@@ -1,7 +1,9 @@
+import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { DEFAULT_PROVIDERS } from '../providers';
 import { ConnectPage } from './ConnectPage';
 import { WebBTCProvider } from '@stacks/connect-ui';
+import { connect } from '../request';
 
 // Define window types
 declare global {
@@ -57,5 +59,80 @@ export const WithMockedWallet: Story = {
         alert('MockedProvider.authenticationRequest()');
       },
     };
+  },
+};
+
+// 4. With approved providers only
+export const WithApprovedProvidersOnly: Story = {
+  render: () => {
+    const handleConnect = () => {
+      return connect({
+        approvedProviderIds: ['LeatherProvider'],
+      });
+    };
+
+    return (
+      <ConnectPage customConnectFunction={handleConnect}>
+        <p>This demo only allows Leather wallet. Click connect() to test.</p>
+      </ConnectPage>
+    );
+  },
+};
+
+// 5. With multiple approved providers
+export const WithMultipleApprovedProviders: Story = {
+  render: () => {
+    const handleConnect = () => {
+      return connect({
+        approvedProviderIds: ['LeatherProvider', 'FordefiProviders.UtxoProvider'],
+      });
+    };
+
+    return (
+      <ConnectPage customConnectFunction={handleConnect}>
+        <p>This demo allows only Leather and Fordefi wallets. Click connect() to test.</p>
+      </ConnectPage>
+    );
+  },
+};
+
+// 6. With approved providers and custom default providers
+export const WithApprovedAndCustomProviders: Story = {
+  render: () => {
+    const handleConnect = () => {
+      // Create a custom set of providers
+      const customProviders = [
+        {
+          id: 'custom-wallet-1',
+          name: 'Custom Wallet 1',
+          icon: 'https://via.placeholder.com/48',
+        },
+        {
+          id: 'leather',
+          name: 'Custom Leather',
+          icon: 'https://www.leather.io/favicon.ico',
+        },
+        {
+          id: 'custom-wallet-2',
+          name: 'Custom Wallet 2',
+          icon: 'https://via.placeholder.com/48',
+        },
+      ];
+
+      return connect({
+        approvedProviderIds: ['leather', 'xverse'],
+        defaultProviders: customProviders,
+        forceWalletSelect: true,
+      });
+    };
+
+    return (
+      <ConnectPage customConnectFunction={handleConnect}>
+        <p>
+          This demo combines approvedProviderIds with custom defaultProviders. Only "Custom Leather"
+          should appear.
+        </p>
+      </ConnectPage>
+    );
   },
 };

--- a/packages/connect/src/stories/ConnectPage.tsx
+++ b/packages/connect/src/stories/ConnectPage.tsx
@@ -1021,7 +1021,13 @@ const STXSignStructuredMessageForm = () => {
 };
 
 // Main ConnectPage Component
-export const ConnectPage = ({ children }: { children?: any }) => {
+export const ConnectPage = ({
+  children,
+  customConnectFunction,
+}: {
+  children?: any;
+  customConnectFunction?: () => Promise<any>;
+}) => {
   const refresh = useReducer(x => x + 1, 0)[1];
   const isSignedIn = userSession.isUserSignedIn();
   const [connectResponse, setConnectResponse] = useState<any>(null);
@@ -1084,7 +1090,7 @@ export const ConnectPage = ({ children }: { children?: any }) => {
               return;
             }
 
-            void connect()
+            void (customConnectFunction ? customConnectFunction() : connect())
               .then(setConnectResponse)
               .then(() => {
                 // Explicitly update the localStorage data after successful connection
@@ -1101,6 +1107,8 @@ export const ConnectPage = ({ children }: { children?: any }) => {
       </header>
 
       <main>
+        <center>{children}</center>
+
         <section>
           <h2>Wallet</h2>
           <div>
@@ -1152,8 +1160,6 @@ export const ConnectPage = ({ children }: { children?: any }) => {
           </>
         )}
       </main>
-
-      {children}
     </div>
   );
 };


### PR DESCRIPTION
> This PR was published to npm with versions:
> - connect `npm install @stacks/connect@8.1.6-alpha.f852d9a.0 --save-exact`
> - connect-react `npm install @stacks/connect-react@23.0.9-alpha.f852d9a.0 --save-exact`
> - connect-ui `npm install @stacks/connect-ui@8.0.1-alpha.f852d9a.0 --save-exact`<!-- Sticky Header Marker -->

- adds missing `approvedProviderIds` as commented by TM
- updates README to make support more clear for Zest
- exports error types