### PR TITLE
fix: remove referrer check for AsignaProvider iframe injection

### DIFF
--- a/.changeset/silent-penguins-worry.md
+++ b/.changeset/silent-penguins-worry.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Fix Asigna iframe check

--- a/packages/connect/src/asigna.ts
+++ b/packages/connect/src/asigna.ts
@@ -26,8 +26,8 @@ const generateAsignaMessage = (payload: string, key: string) => ({ source, [key]
 export const initializeAsignaProvider = () => {
   if (typeof window === 'undefined') return;
 
-  const isAsignaIframe = !!window.top && document.referrer.endsWith('.asigna.io/');
-  if (isAsignaIframe) {
+  const isIframe = window.top !== window.self;
+  if (isIframe) {
     window['AsignaProvider'] = AsignaIframeProvider;
   }
 };


### PR DESCRIPTION
Referrer field is unreliable in some cases when user has vpn turned on, so it's enough to check if it's in iframe or not to add AsignaProvider.