### PR TITLE
fix: add override for publickey in stx_signMessage

### DIFF
--- a/.changeset/slow-rocks-destroy.md
+++ b/.changeset/slow-rocks-destroy.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Add override for experimental non-standard parameter `publicKey` in the `stx_signMessage` wallet method. This parameter will now be stripped for non-Xverse-like wallets.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9740,6 +9740,10 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/connect-ui-loader": {
+      "resolved": "packages/connect-ui/loader",
+      "link": true
+    },
     "node_modules/consola": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.2.3.tgz",
@@ -26396,7 +26400,7 @@
     },
     "packages/connect": {
       "name": "@stacks/connect",
-      "version": "8.1.7",
+      "version": "8.1.8",
       "license": "MIT",
       "dependencies": {
         "@scure/base": "^1.2.4",
@@ -26434,10 +26438,10 @@
     },
     "packages/connect-react": {
       "name": "@stacks/connect-react",
-      "version": "23.0.10",
+      "version": "23.0.11",
       "license": "MIT",
       "dependencies": {
-        "@stacks/connect": "8.1.7"
+        "@stacks/connect": "8.1.8"
       },
       "devDependencies": {
         "@types/react-dom": "^18.3.1",
@@ -26466,8 +26470,7 @@
       }
     },
     "packages/connect-ui/loader": {
-      "name": "connect-ui-loader",
-      "extraneous": true
+      "name": "connect-ui-loader"
     },
     "packages/connect-ui/node_modules/@types/node": {
       "version": "14.18.63",

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -456,23 +456,23 @@ const response = await requestRaw(provider, 'method', params);
 
 Here's a list of methods and events that are supported by popular wallets:
 
-| Method                      | Leather                                            | Xverse-like                                                                    |
-| --------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------ |
-| `getAddresses`              | 🟡 <sub>No support for experimental purposes</sub> | 🟡 <sub>Use `wallet_connect` instead</sub>                                     |
-| `sendTransfer`              | 🟡 <sub>Expects `amount` as string</sub>           | 🟡 <sub>Expects `amount` as number</sub>                                       |
-| `signPsbt`                  | 🟡 <sub>Uses signing index array only</sub>        | 🟡 <sub>Uses `signInputs` record instead of array</sub>                        |
-| `stx_getAddresses`          | 🟢                                                 | 🔴                                                                             |
-| `stx_getAccounts`           | 🔴                                                 | 🟢                                                                             |
-| `stx_getNetworks`           | 🔴                                                 | 🔴                                                                             |
-| `stx_transferStx`           | 🟢                                                 | 🟢                                                                             |
-| `stx_transferSip10Ft`       | 🟢                                                 | 🔴                                                                             |
-| `stx_transferSip9Nft`       | 🟢                                                 | 🔴                                                                             |
-| `stx_callContract`          | 🟡 <sub>Hex-encoded Clarity values only</sub>      | 🟡 <sub>Hex-encoded Clarity values only, no support for `postConditions`</sub> |
-| `stx_deployContract`        | 🟡 <sub>Hex-encoded Clarity values only</sub>      | 🟡 <sub>Hex-encoded Clarity values only, no support for `postConditions`</sub> |
-| `stx_signTransaction`       | 🟡 <sub>Hex-encoded Clarity values only</sub>      | 🟡 <sub>Hex-encoded Clarity values only</sub>                                  |
-| `stx_signMessage`           | 🟡 <sub>Hex-encoded Clarity values only</sub>      | 🟡 <sub>Hex-encoded Clarity values only</sub>                                  |
-| `stx_signStructuredMessage` | 🟡 <sub>Hex-encoded Clarity values only</sub>      | 🟡 <sub>Hex-encoded Clarity values only</sub>                                  |
-| `stx_updateProfile`         | 🔴                                                 | 🔴                                                                             |
+| Method                      | Leather                                                         | Xverse-like                                                                                      |
+| --------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `getAddresses`              | 🟡 <sub>No support for experimental `purpose`</sub>             | 🟡 <sub>Use `wallet_connect` instead</sub>                                                       |
+| `sendTransfer`              | 🟡 <sub>Expects `amount` as string</sub>                        | 🟡 <sub>Expects `amount` as number</sub>                                                         |
+| `signPsbt`                  | 🟡 <sub>Uses signing index array only</sub>                     | 🟡 <sub>Uses `signInputs` record instead of array</sub>                                          |
+| `stx_getAddresses`          | 🟢                                                              | 🔴                                                                                               |
+| `stx_getAccounts`           | 🔴                                                              | 🟢                                                                                               |
+| `stx_getNetworks`           | 🔴                                                              | 🔴                                                                                               |
+| `stx_transferStx`           | 🟢                                                              | 🟢                                                                                               |
+| `stx_transferSip10Ft`       | 🟢                                                              | 🔴                                                                                               |
+| `stx_transferSip9Nft`       | 🟢                                                              | 🔴                                                                                               |
+| `stx_callContract`          | 🟡 <sub>Hex-encoded Clarity values & post-conditions only</sub> | 🟡 <sub>Hex-encoded Clarity values & post-conditions only, no support for `postConditions`</sub> |
+| `stx_deployContract`        | 🟡 <sub>Hex-encoded post-conditions only</sub>                  | 🟡 <sub>Hex-encoded post-conditions only, no support for `postConditions`</sub>                  |
+| `stx_signTransaction`       | 🟢                                                              | 🟢                                                                                               |
+| `stx_signMessage`           | 🟡 <sub>No support for non-standard `publicKey` parameter</sub> | 🟡 <sub>Requires non-standard `publicKey` parameter</sub>                                        |
+| `stx_signStructuredMessage` | 🟡 <sub>Hex-encoded Clarity values only</sub>                   | 🟡 <sub>Hex-encoded Clarity values only</sub>                                                    |
+| `stx_updateProfile`         | 🔴                                                              | 🔴                                                                                               |
 
 | Event               | Leather | Xverse |
 | ------------------- | ------- | ------ |

--- a/packages/connect/src/methods.ts
+++ b/packages/connect/src/methods.ts
@@ -101,6 +101,11 @@ export interface SignTransactionParams {
 
 export interface SignMessageParams {
   message: string;
+  /**
+   * ⚠︎ **Attention**: `.publicKey` is a non-standard parameter. Its usage is not recommended, but may be supported by some wallets.
+   * @experimental This parameter may be removed in the future, when wallets align more.
+   */
+  publicKey?: string;
 }
 
 export interface SignStructuredMessageParams {

--- a/packages/connect/src/request.ts
+++ b/packages/connect/src/request.ts
@@ -444,6 +444,13 @@ function getMethodOverrides<M extends keyof Methods>(
     return { method, params: paramsXverse };
   }
 
+  // Non-Xverse-ish `stx_signMessage`
+  if (!isXverseLike(provider) && method === 'stx_signMessage') {
+    const p = { ...(params as MethodParams<'stx_signMessage'>) };
+    delete p.publicKey;
+    return { method, params: p };
+  }
+
   // Leather `sendTransfer`
   if (isLeather(provider) && method === 'sendTransfer') {
     const paramsLeather = {

--- a/packages/connect/src/stories/ConnectPage.tsx
+++ b/packages/connect/src/stories/ConnectPage.tsx
@@ -896,16 +896,18 @@ const STXDeployContractForm = () => {
 const STXSignMessageForm = () => {
   type STXSignMessageFormData = {
     message: string;
+    publicKey?: string;
   };
   const methods = useForm<STXSignMessageFormData>();
   const { register, handleSubmit } = methods;
   const refresh = useReducer(x => x + 1, 0)[1];
   const [response, setResponse] = useState<any>(null);
 
-  const onSubmit = handleSubmit(({ message }, e) => {
+  const onSubmit = handleSubmit(({ message, publicKey }, e) => {
     e.preventDefault();
     request('stx_signMessage', {
       message,
+      publicKey,
     })
       .then(d => {
         setResponse(d);
@@ -930,6 +932,10 @@ const STXSignMessageForm = () => {
               {...register('message', { required: true })}
               defaultValue="Hello, World!"
             />
+          </div>
+          <div>
+            <label htmlFor="publicKey">Public Key (optional)</label>
+            <input id="publicKey" {...register('publicKey')} placeholder="Optional public key" />
           </div>
           <button type="submit">Sign Message</button>
         </form>


### PR DESCRIPTION
> This PR was published to npm with versions:
> - connect `npm install @stacks/connect@8.1.9-alpha.8efc399.0 --save-exact`
> - connect-react `npm install @stacks/connect-react@23.0.12-alpha.8efc399.0 --save-exact`
> - connect-ui `npm install @stacks/connect-ui@8.0.1-alpha.8efc399.0 --save-exact`<!-- Sticky Header Marker -->

Background:
Xverse (and related wallets) require a non-standard param in a method.

This change overrides the params to balance out this behaviour when using the `request` method.

Also updates the demo/testing app add the param in the UI.
