### PR TITLE
fix: remove functions in serializeParams

### DIFF
--- a/.changeset/small-tigers-refuse.md
+++ b/.changeset/small-tigers-refuse.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Strip unserializable function values from parameters passed into the request function. This previously caused errors during JSON serialization in some providers.

--- a/packages/connect/src/request.ts
+++ b/packages/connect/src/request.ts
@@ -506,12 +506,6 @@ export function serializeParams<M extends keyof Methods>(params: MethodParams<M>
     // Keep original value, don't override
     if (!value) continue;
 
-    // Don't serialize functions (like `onFinish`, `onCancel`)
-    if (typeof value === 'function') {
-      delete result[key];
-      continue;
-    }
-
     // Handle array of things
     if (Array.isArray(value)) {
       result[key] = value.map(item => {

--- a/packages/connect/src/request.ts
+++ b/packages/connect/src/request.ts
@@ -527,7 +527,7 @@ export function serializeParams<M extends keyof Methods>(params: MethodParams<M>
     }
   }
 
-  return JSON.parse(JSON.stringify(result)); // Just in case
+  return JSON.parse(JSON.stringify(result)); // Strip unserializable values
 }
 
 /** @internal Higher order function for persisting the selected provider */

--- a/packages/connect/src/request.ts
+++ b/packages/connect/src/request.ts
@@ -533,7 +533,7 @@ export function serializeParams<M extends keyof Methods>(params: MethodParams<M>
     }
   }
 
-  return result;
+  return JSON.parse(JSON.stringify(result)); // Just in case
 }
 
 /** @internal Higher order function for persisting the selected provider */

--- a/packages/connect/src/request.ts
+++ b/packages/connect/src/request.ts
@@ -506,6 +506,12 @@ export function serializeParams<M extends keyof Methods>(params: MethodParams<M>
     // Keep original value, don't override
     if (!value) continue;
 
+    // Don't serialize functions (like `onFinish`, `onCancel`)
+    if (typeof value === 'function') {
+      delete result[key];
+      continue;
+    }
+
     // Handle array of things
     if (Array.isArray(value)) {
       result[key] = value.map(item => {

--- a/packages/connect/src/stories/ConnectPage.tsx
+++ b/packages/connect/src/stories/ConnectPage.tsx
@@ -165,8 +165,8 @@ const LegacyContractCallForm = () => {
               .split('')
               .reduce(
                 (acc, char) => {
-                  if (char === '(') acc.p++;
-                  if (char === ')') acc.p--;
+                  if (char === '(' || char === '{') acc.p++;
+                  if (char === ')' || char === '}') acc.p--;
                   if (char === ',' && !acc.p) {
                     acc.segs.push('');
                   } else {
@@ -735,8 +735,8 @@ const STXContractCallForm = () => {
             .split('')
             .reduce(
               (acc, char) => {
-                if (char === '(') acc.p++;
-                if (char === ')') acc.p--;
+                if (char === '(' || char === '{') acc.p++;
+                if (char === ')' || char === '}') acc.p--;
                 if (char === ',' && !acc.p) {
                   acc.segs.push('');
                 } else {

--- a/packages/connect/tests/request.test.ts
+++ b/packages/connect/tests/request.test.ts
@@ -73,10 +73,16 @@ describe('serializeParams', () => {
       onFinish: () => {
         console.log('finished');
       },
+      network: {
+        client: {
+          fetch: () => Promise.resolve({}),
+        },
+      },
       num: 123,
     };
     expect(serializeParams(params as any)).toEqual({
       str: 'hello',
+      network: { client: {} },
       num: 123,
     });
   });

--- a/packages/connect/tests/request.test.ts
+++ b/packages/connect/tests/request.test.ts
@@ -66,4 +66,18 @@ describe('serializeParams', () => {
     };
     expect(serializeParams(params as any)).toEqual(params);
   });
+
+  it('should remove functions from params', () => {
+    const params = {
+      str: 'hello',
+      onFinish: () => {
+        console.log('finished');
+      },
+      num: 123,
+    };
+    expect(serializeParams(params as any)).toEqual({
+      str: 'hello',
+      num: 123,
+    });
+  });
 });


### PR DESCRIPTION
> This PR was published to npm with versions:
> - connect `npm install @stacks/connect@8.1.10-alpha.4875af9.0 --save-exact`
> - connect-react `npm install @stacks/connect-react@23.0.13-alpha.4875af9.0 --save-exact`
> - connect-ui `npm install @stacks/connect-ui@8.0.1-alpha.4875af9.0 --save-exact`<!-- Sticky Header Marker -->

Strip unserializable function values from parameters passed into the request function. This previously caused errors during JSON serialization in some providers.