### PR TITLE
chore: rename wallet connect config

### DIFF
--- a/.changeset/eighty-candles-sniff.md
+++ b/.changeset/eighty-candles-sniff.md
@@ -2,4 +2,4 @@
 '@stacks/connect': patch
 ---
 
-Add preferred `walletConnectConfig` option to ConnectRequestOptions. Deprecate `walletConnectProjectId` in favor of nested config object
+Add preferred `walletConnect` option to ConnectRequestOptions. Deprecate `walletConnectProjectId` in favor of nested config object


### PR DESCRIPTION
- small rename `walletConnectConfig` → `walletConnect`