### PR TITLE
chore: add stacks testnet support to WC connector

### DIFF
--- a/.changeset/afraid-animals-juggle.md
+++ b/.changeset/afraid-animals-juggle.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+Adds support for testnet on WalletConnect wallet

--- a/packages/connect/src/walletconnect/config.ts
+++ b/packages/connect/src/walletconnect/config.ts
@@ -28,6 +28,15 @@ export const stacksMainnet: CustomCaipNetwork<'stacks'> = {
   rpcUrls: { default: { http: ['https://api.mainnet.hiro.so'] } },
 };
 
+export const stacksTestnet: CustomCaipNetwork<'stacks'> = {
+  id: 2,
+  chainNamespace: 'stacks' as const,
+  caipNetworkId: 'stacks:2147483648',
+  name: 'Stacks Testnet',
+  nativeCurrency: { name: 'STX', symbol: 'STX', decimals: 6 },
+  rpcUrls: { default: { http: ['https://api.testnet.hiro.so'] } },
+};
+
 export const DEFAULT_WALLETCONNECT_CONFIG: Omit<UniversalConnectorConfig, 'projectId'> = {
   metadata: {
     name: 'Universal Connector',
@@ -38,7 +47,7 @@ export const DEFAULT_WALLETCONNECT_CONFIG: Omit<UniversalConnectorConfig, 'proje
   networks: [
     {
       namespace: 'stacks',
-      chains: [stacksMainnet as CustomCaipNetwork],
+      chains: [stacksMainnet, stacksTestnet],
       methods: stacksMethods,
       events: ['stx_chainChanged', 'stx_accountsChanged'],
     },

--- a/packages/connect/src/walletconnect/index.ts
+++ b/packages/connect/src/walletconnect/index.ts
@@ -109,7 +109,10 @@ class WalletConnectProvider implements StacksProvider {
     }
   }
 
-  private getTargetCaipNetworkId<M extends keyof MethodsRaw>(method: M, params?: MethodParamsRaw<M>) {
+  private getTargetCaipNetworkId<M extends keyof MethodsRaw>(
+    method: M,
+    params?: MethodParamsRaw<M>
+  ) {
     const accountMethods = ['getAddresses', 'stx_getAccounts', 'stx_getAddresses'];
     const network = 'network' in params ? (params.network as NetworkString) : undefined;
 
@@ -119,7 +122,6 @@ class WalletConnectProvider implements StacksProvider {
         testnet: stacksTestnet.caipNetworkId,
       }[network];
     }
-
 
     if (accountMethods.includes(method)) {
       return stacksMainnet.caipNetworkId;

--- a/packages/connect/src/walletconnect/index.ts
+++ b/packages/connect/src/walletconnect/index.ts
@@ -5,10 +5,11 @@ import {
   JsonRpcResponse,
   MethodParamsRaw,
   MethodsRaw,
+  NetworkString,
   SignMessageResult,
 } from '../methods';
 import { StacksProvider } from '../types/provider';
-import { DEFAULT_WALLETCONNECT_CONFIG, stacksMainnet } from './config';
+import { DEFAULT_WALLETCONNECT_CONFIG, stacksMainnet, stacksTestnet } from './config';
 import { bitcoin } from '@reown/appkit/networks';
 
 function jsonRpcResponse<M extends keyof MethodsRaw>(result: unknown): JsonRpcResponse<M> {
@@ -108,8 +109,18 @@ class WalletConnectProvider implements StacksProvider {
     }
   }
 
-  private getTargetCaipNetworkId(method: keyof MethodsRaw) {
+  private getTargetCaipNetworkId<M extends keyof MethodsRaw>(method: M, params?: MethodParamsRaw<M>) {
     const accountMethods = ['getAddresses', 'stx_getAccounts', 'stx_getAddresses'];
+    const network = 'network' in params ? (params.network as NetworkString) : undefined;
+
+    if (network) {
+      return {
+        mainnet: stacksMainnet.caipNetworkId,
+        testnet: stacksTestnet.caipNetworkId,
+      }[network];
+    }
+
+
     if (accountMethods.includes(method)) {
       return stacksMainnet.caipNetworkId;
     }
@@ -133,7 +144,7 @@ class WalletConnectProvider implements StacksProvider {
   ): Promise<JsonRpcResponse<M>> {
     try {
       this.validateRpcMethod(method);
-      const caipNetworkId = this.getTargetCaipNetworkId(method);
+      const caipNetworkId = this.getTargetCaipNetworkId(method, params);
 
       switch (method) {
         case 'getAddresses':


### PR DESCRIPTION
## Description
Adds support for `stacksTestnet` on `walletconnectWallet`

1. Motivation for change
Users trying to target testnet are not able to

2. What was changed
No public interface changes, `request` now picks up `network` parameter if present and maps to corresponding CAIP id

3. How does this impact application developers
Allows them to target testnet in their requests

4. Link to relevant issues and documentation
N/A

5. Provide examples of use cases with code samples and applicable acceptance criteria
`wcWallet.request('stx_sendTransaction', { network: 'testnet' })` will now target testnet on WC provider


## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Are documentation updates required?
Unsure where to push this
- [ ] Link to documentation updates:

## Checklist

- [x] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] Changelog is updated
- [x] Tag @janniks for review
